### PR TITLE
feat: complete resume builder v2

### DIFF
--- a/src/__tests__/ResumeSectionsForm.test.js
+++ b/src/__tests__/ResumeSectionsForm.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ResumeSectionsForm from '../components/forms/ResumeSectionsForm';
+
+const renderForm = (overrides = {}) => {
+  const onChange = jest.fn();
+  render(<ResumeSectionsForm education={[]} certifications={[]} projects={[]} onChange={onChange} {...overrides} />);
+  return onChange;
+};
+
+test('renders all resume section editors', () => {
+  renderForm();
+  expect(screen.getByText('Education')).toBeInTheDocument();
+  expect(screen.getByText('Certifications')).toBeInTheDocument();
+  expect(screen.getByText('Projects')).toBeInTheDocument();
+});
+
+test('adds an education item', async () => {
+  const user = userEvent.setup();
+  const onChange = renderForm();
+  await user.click(screen.getByRole('button', { name: /add education/i }));
+  expect(onChange).toHaveBeenCalledWith('education', [expect.objectContaining({ degree: '' })]);
+});
+
+test('adds a certification item', async () => {
+  const user = userEvent.setup();
+  const onChange = renderForm();
+  await user.click(screen.getByRole('button', { name: /add certification/i }));
+  expect(onChange).toHaveBeenCalledWith('certifications', [expect.objectContaining({ name: '' })]);
+});
+
+test('adds a project item', async () => {
+  const user = userEvent.setup();
+  const onChange = renderForm();
+  await user.click(screen.getByRole('button', { name: /add project/i }));
+  expect(onChange).toHaveBeenCalledWith('projects', [expect.objectContaining({ name: '' })]);
+});

--- a/src/components/forms/ResumeSectionsForm.js
+++ b/src/components/forms/ResumeSectionsForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Award, BriefcaseBusiness, GraduationCap, Plus, Trash2 } from 'lucide-react';
 import Button from '../common/Button';
 import Input from '../common/Input';
@@ -22,10 +22,18 @@ const Field = ({ label, value, onChange, placeholder, type = 'text' }) => (
 );
 
 const ResumeSectionsForm = ({ education, certifications, projects, onChange }) => {
-  const [open, setOpen] = useState({ education: true, certifications: false, projects: false });
-  const update = (key, index, patch) => onChange(key, (key === 'education' ? education : key === 'certifications' ? certifications : projects).map((item, i) => i === index ? { ...item, ...patch } : item));
-  const remove = (key, index) => onChange(key, (key === 'education' ? education : key === 'certifications' ? certifications : projects).filter((_, i) => i !== index));
-  const add = (key, item) => { onChange(key, [...(key === 'education' ? education : key === 'certifications' ? certifications : projects), item]); setOpen((v) => ({ ...v, [key]: true })); };
+  const update = (key, index, patch) => {
+    const items = key === 'education' ? education : key === 'certifications' ? certifications : projects;
+    onChange(key, items.map((item, i) => i === index ? { ...item, ...patch } : item));
+  };
+  const remove = (key, index) => {
+    const items = key === 'education' ? education : key === 'certifications' ? certifications : projects;
+    onChange(key, items.filter((_, i) => i !== index));
+  };
+  const add = (key, item) => {
+    const items = key === 'education' ? education : key === 'certifications' ? certifications : projects;
+    onChange(key, [...items, item]);
+  };
 
   return (
     <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-6 mb-8 border border-gray-100 dark:border-gray-700">
@@ -33,54 +41,38 @@ const ResumeSectionsForm = ({ education, certifications, projects, onChange }) =
       <div className="space-y-4">
         <Section title="Education" icon={GraduationCap} addLabel="Add Education" onAdd={() => add('education', emptyEducation())}>
           {education.length === 0 && <p className="text-sm text-gray-500">Add your degrees, universities and graduation details.</p>}
-          {open.education && education.map((edu, i) => (
-            <div key={edu.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0">
-              <div className="grid md:grid-cols-2 gap-4">
-                <Field label="Degree" value={edu.degree} onChange={(v) => update('education', i, { degree: v })} placeholder="B.Tech in Computer Science" />
-                <Field label="Institution" value={edu.institution} onChange={(v) => update('education', i, { institution: v })} placeholder="IIT Bombay" />
-                <Field label="Location" value={edu.location} onChange={(v) => update('education', i, { location: v })} placeholder="Mumbai, India" />
-                <Field label="GPA / Grade" value={edu.gpa} onChange={(v) => update('education', i, { gpa: v })} placeholder="8.7/10" />
-                <Field label="Start Year" value={edu.startYear} onChange={(v) => update('education', i, { startYear: v })} placeholder="2017" />
-                <Field label="End / Graduation Year" value={edu.endYear || edu.graduationYear} onChange={(v) => update('education', i, { endYear: v, graduationYear: v })} placeholder="2021" />
-              </div>
-              <button onClick={() => remove('education', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button>
-            </div>
-          ))}
+          {education.map((edu, i) => <div key={edu.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0"><div className="grid md:grid-cols-2 gap-4">
+            <Field label="Degree" value={edu.degree} onChange={(v) => update('education', i, { degree: v })} placeholder="B.Tech in Computer Science" />
+            <Field label="Institution" value={edu.institution} onChange={(v) => update('education', i, { institution: v })} placeholder="IIT Bombay" />
+            <Field label="Location" value={edu.location} onChange={(v) => update('education', i, { location: v })} placeholder="Mumbai, India" />
+            <Field label="GPA / Grade" value={edu.gpa} onChange={(v) => update('education', i, { gpa: v })} placeholder="8.7/10" />
+            <Field label="Start Year" value={edu.startYear} onChange={(v) => update('education', i, { startYear: v })} placeholder="2017" />
+            <Field label="End / Graduation Year" value={edu.endYear || edu.graduationYear} onChange={(v) => update('education', i, { endYear: v, graduationYear: v })} placeholder="2021" />
+          </div><button onClick={() => remove('education', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button></div>)}
         </Section>
 
         <Section title="Certifications" icon={Award} addLabel="Add Certification" onAdd={() => add('certifications', emptyCertification())}>
           {certifications.length === 0 && <p className="text-sm text-gray-500">Add professional certifications and credentials.</p>}
-          {open.certifications && certifications.map((cert, i) => (
-            <div key={cert.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0">
-              <div className="grid md:grid-cols-2 gap-4">
-                <Field label="Certification" value={cert.name} onChange={(v) => update('certifications', i, { name: v })} placeholder="AWS Certified Developer" />
-                <Field label="Issuing Organization" value={cert.issuer} onChange={(v) => update('certifications', i, { issuer: v })} placeholder="Amazon Web Services" />
-                <Field label="Issue Date" value={cert.issueDate} onChange={(v) => update('certifications', i, { issueDate: v })} type="date" />
-                <Field label="Expiry Date" value={cert.expiryDate} onChange={(v) => update('certifications', i, { expiryDate: v })} type="date" />
-                <Field label="Credential ID" value={cert.credentialId} onChange={(v) => update('certifications', i, { credentialId: v })} placeholder="ABC123" />
-                <Field label="Credential URL" value={cert.url} onChange={(v) => update('certifications', i, { url: v })} placeholder="https://..." type="url" />
-              </div>
-              <button onClick={() => remove('certifications', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button>
-            </div>
-          ))}
+          {certifications.map((cert, i) => <div key={cert.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0"><div className="grid md:grid-cols-2 gap-4">
+            <Field label="Certification" value={cert.name} onChange={(v) => update('certifications', i, { name: v })} placeholder="AWS Certified Developer" />
+            <Field label="Issuing Organization" value={cert.issuer} onChange={(v) => update('certifications', i, { issuer: v })} placeholder="Amazon Web Services" />
+            <Field label="Issue Date" value={cert.issueDate} onChange={(v) => update('certifications', i, { issueDate: v })} type="date" />
+            <Field label="Expiry Date" value={cert.expiryDate} onChange={(v) => update('certifications', i, { expiryDate: v })} type="date" />
+            <Field label="Credential ID" value={cert.credentialId} onChange={(v) => update('certifications', i, { credentialId: v })} placeholder="ABC123" />
+            <Field label="Credential URL" value={cert.url} onChange={(v) => update('certifications', i, { url: v })} placeholder="https://..." type="url" />
+          </div><button onClick={() => remove('certifications', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button></div>)}
         </Section>
 
         <Section title="Projects" icon={BriefcaseBusiness} addLabel="Add Project" onAdd={() => add('projects', emptyProject())}>
           {projects.length === 0 && <p className="text-sm text-gray-500">Showcase high-impact projects, technologies and links.</p>}
-          {open.projects && projects.map((project, i) => (
-            <div key={project.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0">
-              <div className="grid md:grid-cols-2 gap-4">
-                <Field label="Project Name" value={project.name} onChange={(v) => update('projects', i, { name: v })} placeholder="Career Resume Builder" />
-                <Field label="Technologies" value={project.technologies} onChange={(v) => update('projects', i, { technologies: v })} placeholder="React, Node.js, AWS" />
-                <Field label="Project URL" value={project.url} onChange={(v) => update('projects', i, { url: v })} placeholder="https://..." type="url" />
-                <Field label="GitHub URL" value={project.github} onChange={(v) => update('projects', i, { github: v })} placeholder="https://github.com/..." type="url" />
-                <Field label="Start Date" value={project.startDate} onChange={(v) => update('projects', i, { startDate: v })} type="date" />
-                <Field label="End Date" value={project.endDate} onChange={(v) => update('projects', i, { endDate: v })} type="date" />
-              </div>
-              <div className="mt-4"><label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Description</label><textarea value={project.description || ''} onChange={(e) => update('projects', i, { description: e.target.value })} rows={3} className="w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-slate-700 text-gray-800 dark:text-gray-100" placeholder="What did you build and what impact did it have?" /></div>
-              <button onClick={() => remove('projects', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button>
-            </div>
-          ))}
+          {projects.map((project, i) => <div key={project.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0"><div className="grid md:grid-cols-2 gap-4">
+            <Field label="Project Name" value={project.name} onChange={(v) => update('projects', i, { name: v })} placeholder="Career Resume Builder" />
+            <Field label="Technologies" value={project.technologies} onChange={(v) => update('projects', i, { technologies: v })} placeholder="React, Node.js, AWS" />
+            <Field label="Project URL" value={project.url} onChange={(v) => update('projects', i, { url: v })} placeholder="https://..." type="url" />
+            <Field label="GitHub URL" value={project.github} onChange={(v) => update('projects', i, { github: v })} placeholder="https://github.com/..." type="url" />
+            <Field label="Start Date" value={project.startDate} onChange={(v) => update('projects', i, { startDate: v })} type="date" />
+            <Field label="End Date" value={project.endDate} onChange={(v) => update('projects', i, { endDate: v })} type="date" />
+          </div><div className="mt-4"><label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Description</label><textarea value={project.description || ''} onChange={(e) => update('projects', i, { description: e.target.value })} rows={3} className="w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-slate-700 text-gray-800 dark:text-gray-100" placeholder="What did you build and what impact did it have?" /></div><button onClick={() => remove('projects', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button></div>)}
         </Section>
       </div>
     </div>

--- a/src/components/forms/ResumeSectionsForm.js
+++ b/src/components/forms/ResumeSectionsForm.js
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { Award, BriefcaseBusiness, GraduationCap, Plus, Trash2 } from 'lucide-react';
+import Button from '../common/Button';
+import Input from '../common/Input';
+
+const emptyEducation = () => ({ id: Date.now(), degree: '', institution: '', location: '', startYear: '', endYear: '', gpa: '' });
+const emptyCertification = () => ({ id: Date.now(), name: '', issuer: '', issueDate: '', expiryDate: '', credentialId: '', url: '' });
+const emptyProject = () => ({ id: Date.now(), name: '', description: '', technologies: '', url: '', github: '', startDate: '', endDate: '' });
+
+const Section = ({ title, icon: Icon, children, onAdd, addLabel }) => (
+  <section className="bg-gray-50 dark:bg-slate-900/60 rounded-xl p-5 border border-gray-200 dark:border-gray-700">
+    <div className="flex items-center justify-between mb-4">
+      <h3 className="font-bold text-gray-800 dark:text-white flex items-center"><Icon className="w-5 h-5 mr-2 text-linkedin-600" />{title}</h3>
+      <Button onClick={onAdd} variant="secondary"><Plus className="w-4 h-4 mr-1" />{addLabel}</Button>
+    </div>
+    {children}
+  </section>
+);
+
+const Field = ({ label, value, onChange, placeholder, type = 'text' }) => (
+  <Input label={label} value={value || ''} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} type={type} />
+);
+
+const ResumeSectionsForm = ({ education, certifications, projects, onChange }) => {
+  const [open, setOpen] = useState({ education: true, certifications: false, projects: false });
+  const update = (key, index, patch) => onChange(key, (key === 'education' ? education : key === 'certifications' ? certifications : projects).map((item, i) => i === index ? { ...item, ...patch } : item));
+  const remove = (key, index) => onChange(key, (key === 'education' ? education : key === 'certifications' ? certifications : projects).filter((_, i) => i !== index));
+  const add = (key, item) => { onChange(key, [...(key === 'education' ? education : key === 'certifications' ? certifications : projects), item]); setOpen((v) => ({ ...v, [key]: true })); };
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-6 mb-8 border border-gray-100 dark:border-gray-700">
+      <h2 className="text-xl font-bold text-gray-800 dark:text-white mb-5">Resume Sections</h2>
+      <div className="space-y-4">
+        <Section title="Education" icon={GraduationCap} addLabel="Add Education" onAdd={() => add('education', emptyEducation())}>
+          {education.length === 0 && <p className="text-sm text-gray-500">Add your degrees, universities and graduation details.</p>}
+          {open.education && education.map((edu, i) => (
+            <div key={edu.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0">
+              <div className="grid md:grid-cols-2 gap-4">
+                <Field label="Degree" value={edu.degree} onChange={(v) => update('education', i, { degree: v })} placeholder="B.Tech in Computer Science" />
+                <Field label="Institution" value={edu.institution} onChange={(v) => update('education', i, { institution: v })} placeholder="IIT Bombay" />
+                <Field label="Location" value={edu.location} onChange={(v) => update('education', i, { location: v })} placeholder="Mumbai, India" />
+                <Field label="GPA / Grade" value={edu.gpa} onChange={(v) => update('education', i, { gpa: v })} placeholder="8.7/10" />
+                <Field label="Start Year" value={edu.startYear} onChange={(v) => update('education', i, { startYear: v })} placeholder="2017" />
+                <Field label="End / Graduation Year" value={edu.endYear || edu.graduationYear} onChange={(v) => update('education', i, { endYear: v, graduationYear: v })} placeholder="2021" />
+              </div>
+              <button onClick={() => remove('education', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button>
+            </div>
+          ))}
+        </Section>
+
+        <Section title="Certifications" icon={Award} addLabel="Add Certification" onAdd={() => add('certifications', emptyCertification())}>
+          {certifications.length === 0 && <p className="text-sm text-gray-500">Add professional certifications and credentials.</p>}
+          {open.certifications && certifications.map((cert, i) => (
+            <div key={cert.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0">
+              <div className="grid md:grid-cols-2 gap-4">
+                <Field label="Certification" value={cert.name} onChange={(v) => update('certifications', i, { name: v })} placeholder="AWS Certified Developer" />
+                <Field label="Issuing Organization" value={cert.issuer} onChange={(v) => update('certifications', i, { issuer: v })} placeholder="Amazon Web Services" />
+                <Field label="Issue Date" value={cert.issueDate} onChange={(v) => update('certifications', i, { issueDate: v })} type="date" />
+                <Field label="Expiry Date" value={cert.expiryDate} onChange={(v) => update('certifications', i, { expiryDate: v })} type="date" />
+                <Field label="Credential ID" value={cert.credentialId} onChange={(v) => update('certifications', i, { credentialId: v })} placeholder="ABC123" />
+                <Field label="Credential URL" value={cert.url} onChange={(v) => update('certifications', i, { url: v })} placeholder="https://..." type="url" />
+              </div>
+              <button onClick={() => remove('certifications', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button>
+            </div>
+          ))}
+        </Section>
+
+        <Section title="Projects" icon={BriefcaseBusiness} addLabel="Add Project" onAdd={() => add('projects', emptyProject())}>
+          {projects.length === 0 && <p className="text-sm text-gray-500">Showcase high-impact projects, technologies and links.</p>}
+          {open.projects && projects.map((project, i) => (
+            <div key={project.id || i} className="border-t dark:border-gray-700 pt-4 mt-4 first:border-0 first:pt-0 first:mt-0">
+              <div className="grid md:grid-cols-2 gap-4">
+                <Field label="Project Name" value={project.name} onChange={(v) => update('projects', i, { name: v })} placeholder="Career Resume Builder" />
+                <Field label="Technologies" value={project.technologies} onChange={(v) => update('projects', i, { technologies: v })} placeholder="React, Node.js, AWS" />
+                <Field label="Project URL" value={project.url} onChange={(v) => update('projects', i, { url: v })} placeholder="https://..." type="url" />
+                <Field label="GitHub URL" value={project.github} onChange={(v) => update('projects', i, { github: v })} placeholder="https://github.com/..." type="url" />
+                <Field label="Start Date" value={project.startDate} onChange={(v) => update('projects', i, { startDate: v })} type="date" />
+                <Field label="End Date" value={project.endDate} onChange={(v) => update('projects', i, { endDate: v })} type="date" />
+              </div>
+              <div className="mt-4"><label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Description</label><textarea value={project.description || ''} onChange={(e) => update('projects', i, { description: e.target.value })} rows={3} className="w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-slate-700 text-gray-800 dark:text-gray-100" placeholder="What did you build and what impact did it have?" /></div>
+              <button onClick={() => remove('projects', i)} className="mt-3 text-sm text-red-600 hover:text-red-700 flex items-center"><Trash2 className="w-4 h-4 mr-1" />Remove</button>
+            </div>
+          ))}
+        </Section>
+      </div>
+    </div>
+  );
+};
+
+export default ResumeSectionsForm;

--- a/src/components/resume/ResumeAdditionalSections.js
+++ b/src/components/resume/ResumeAdditionalSections.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ExternalLink, Github, BriefcaseBusiness } from 'lucide-react';
+
+const ResumeAdditionalSections = ({ projects = [], variant = 'classic' }) => {
+  if (!projects.length) return null;
+  const modern = variant === 'modern';
+  const minimal = variant === 'minimal';
+
+  return (
+    <div className={minimal ? 'mb-10' : 'mb-8'}>
+      <h3 className={minimal ? 'text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4' : modern ? 'text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center' : 'text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center'}>
+        <BriefcaseBusiness className={minimal ? 'w-4 h-4 mr-2 inline' : 'w-5 h-5 mr-2'} />
+        Projects
+      </h3>
+      <div className={modern ? 'space-y-4 pl-6' : 'space-y-5'}>
+        {projects.map((project, index) => (
+          <article key={project.id || index} className={modern ? 'bg-gray-50 rounded-lg p-4' : ''}>
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <h4 className={`${minimal ? 'text-lg font-medium' : 'text-lg font-bold'} text-gray-900`}>{project.name || 'Untitled Project'}</h4>
+              {(project.startDate || project.endDate) && <span className="text-sm text-gray-500">{project.startDate || ''}{project.endDate ? ` - ${project.endDate}` : project.startDate ? ' - Present' : ''}</span>}
+            </div>
+            {project.technologies && <p className={`${minimal ? 'font-light' : 'font-medium'} text-sm text-gray-600 mt-1`}>{project.technologies}</p>}
+            {project.description && <p className="text-gray-700 leading-relaxed mt-2">{project.description}</p>}
+            {(project.url || project.github) && (
+              <div className="flex flex-wrap gap-4 mt-2 text-sm">
+                {project.url && <a href={project.url} target="_blank" rel="noreferrer" className="inline-flex items-center text-linkedin-700 hover:underline"><ExternalLink className="w-3.5 h-3.5 mr-1" />Live project</a>}
+                {project.github && <a href={project.github} target="_blank" rel="noreferrer" className="inline-flex items-center text-gray-700 hover:underline"><Github className="w-3.5 h-3.5 mr-1" />GitHub</a>}
+              </div>
+            )}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ResumeAdditionalSections;

--- a/src/components/resume/templates/ClassicTemplateV2.js
+++ b/src/components/resume/templates/ClassicTemplateV2.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ClassicTemplate from './ClassicTemplate';
+import ResumeAdditionalSections from '../ResumeAdditionalSections';
+
+const ClassicTemplateV2 = React.forwardRef(({ profile, experiences, education = [], certifications = [], projects = [] }, ref) => (
+  <div ref={ref} className="bg-white max-w-4xl mx-auto">
+    <ClassicTemplate profile={profile} experiences={experiences} education={education} certifications={certifications} />
+    <div className="px-12 pb-12">
+      <ResumeAdditionalSections projects={projects} variant="classic" />
+    </div>
+  </div>
+));
+
+ClassicTemplateV2.displayName = 'ClassicTemplateV2';
+export default ClassicTemplateV2;

--- a/src/components/resume/templates/MinimalTemplate.js
+++ b/src/components/resume/templates/MinimalTemplate.js
@@ -1,202 +1,50 @@
 import React from 'react';
 import { Mail, Phone, MapPin, Linkedin, Globe } from 'lucide-react';
 import { formatDate, calculateDuration } from '../../../utils/dateUtils';
+import ResumeAdditionalSections from '../ResumeAdditionalSections';
 
-const MinimalTemplate = React.forwardRef(({ profile, experiences, education = [], certifications = [] }, ref) => {
-  const sortedExperiences = [...experiences].sort((a, b) => {
-    const dateA = new Date(a.startDate);
-    const dateB = new Date(b.startDate);
-    return dateB - dateA;
-  });
-
-  const allSkills = [...new Set(
-    sortedExperiences
-      .filter(exp => exp.skills && exp.skills.length > 0)
-      .flatMap(exp => exp.skills)
-  )];
+const MinimalTemplate = React.forwardRef(({ profile, experiences, education = [], certifications = [], projects = [] }, ref) => {
+  const sortedExperiences = [...experiences].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+  const allSkills = [...new Set(sortedExperiences.filter(exp => exp.skills?.length).flatMap(exp => exp.skills))];
 
   return (
     <div ref={ref} className="bg-white p-16 max-w-4xl mx-auto" style={{ minHeight: '11in', fontFamily: '\'Helvetica Neue\', Arial, sans-serif' }}>
-      {/* Minimal Header */}
       <div className="mb-12">
-        <h1 className="text-5xl font-light text-gray-900 mb-1 tracking-tight">
-          {profile.fullName || 'Your Name'}
-        </h1>
-        {profile.headline && (
-          <p className="text-lg text-gray-600 font-light mb-4">
-            {profile.headline}
-          </p>
-        )}
-        
+        <h1 className="text-5xl font-light text-gray-900 mb-1 tracking-tight">{profile.fullName || 'Your Name'}</h1>
+        {profile.headline && <p className="text-lg text-gray-600 font-light mb-4">{profile.headline}</p>}
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600 font-light border-t border-b border-gray-200 py-3 mt-4">
-          {profile.email && (
-            <div className="flex items-center">
-              <Mail className="w-3.5 h-3.5 mr-1.5" />
-              {profile.email}
-            </div>
-          )}
-          {profile.phone && (
-            <div className="flex items-center">
-              <Phone className="w-3.5 h-3.5 mr-1.5" />
-              {profile.phone}
-            </div>
-          )}
-          {profile.location && (
-            <div className="flex items-center">
-              <MapPin className="w-3.5 h-3.5 mr-1.5" />
-              {profile.location}
-            </div>
-          )}
-          {profile.linkedin && (
-            <div className="flex items-center">
-              <Linkedin className="w-3.5 h-3.5 mr-1.5" />
-              <span>LinkedIn</span>
-            </div>
-          )}
-          {profile.website && (
-            <div className="flex items-center">
-              <Globe className="w-3.5 h-3.5 mr-1.5" />
-              <span>Portfolio</span>
-            </div>
-          )}
+          {profile.email && <div className="flex items-center"><Mail className="w-3.5 h-3.5 mr-1.5" />{profile.email}</div>}
+          {profile.phone && <div className="flex items-center"><Phone className="w-3.5 h-3.5 mr-1.5" />{profile.phone}</div>}
+          {profile.location && <div className="flex items-center"><MapPin className="w-3.5 h-3.5 mr-1.5" />{profile.location}</div>}
+          {profile.linkedin && <div className="flex items-center"><Linkedin className="w-3.5 h-3.5 mr-1.5" />LinkedIn</div>}
+          {profile.website && <div className="flex items-center"><Globe className="w-3.5 h-3.5 mr-1.5" />Portfolio</div>}
         </div>
       </div>
 
-      {/* Professional Summary */}
-      {profile.summary && (
-        <div className="mb-10">
-          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">
-            Summary
-          </h3>
-          <p className="text-gray-700 leading-relaxed font-light">
-            {profile.summary}
-          </p>
+      {profile.summary && <div className="mb-10"><h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">Summary</h3><p className="text-gray-700 leading-relaxed font-light">{profile.summary}</p></div>}
+      {allSkills.length > 0 && <div className="mb-10"><h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">Skills</h3><p className="text-gray-700 font-light">{allSkills.join(' • ')}</p></div>}
+
+      {sortedExperiences.length > 0 && <div className="mb-10">
+        <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">Experience</h3>
+        <div className="space-y-6">
+          {sortedExperiences.map((exp, index) => <div key={exp.id || index}>
+            <div className="flex justify-between items-baseline mb-1 gap-4"><h4 className="text-lg font-medium text-gray-900">{exp.position}</h4><span className="text-sm text-gray-600 font-light whitespace-nowrap">{formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}</span></div>
+            <div className="flex justify-between items-baseline mb-2 gap-4"><p className="text-gray-700 font-light">{exp.company}{exp.location && <span className="text-gray-500"> • {exp.location}</span>}</p><span className="text-sm text-gray-500 font-light whitespace-nowrap">{calculateDuration(exp.startDate, exp.endDate, exp.current)}</span></div>
+            {exp.description && <p className="text-gray-700 mb-2 leading-relaxed font-light">{exp.description}</p>}
+            {exp.skills?.length > 0 && <p className="text-sm text-gray-600 mb-2 italic font-light">{exp.skills.join(', ')}</p>}
+            {exp.achievements?.length > 0 && exp.achievements[0] !== '' && <ul className="space-y-1 text-gray-700 font-light">{exp.achievements.map((achievement, i) => achievement && <li key={i} className="flex items-start"><span className="mr-2">—</span><span>{achievement}</span></li>)}</ul>}
+          </div>)}
         </div>
-      )}
+      </div>}
 
-      {/* Technical Skills */}
-      {allSkills.length > 0 && (
-        <div className="mb-10">
-          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">
-            Skills
-          </h3>
-          <p className="text-gray-700 font-light">
-            {allSkills.join(' • ')}
-          </p>
-        </div>
-      )}
+      {education.length > 0 && <div className="mb-10"><h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">Education</h3><div className="space-y-4">{education.map((edu, index) => <div key={edu.id || index}><div className="flex justify-between items-baseline gap-4"><h4 className="text-lg font-medium text-gray-900">{edu.degree}</h4><span className="text-sm text-gray-600 font-light">{edu.graduationYear || edu.endYear || `${edu.startYear || ''}`}</span></div><p className="text-gray-700 font-light">{edu.institution}{edu.location && ` • ${edu.location}`}{edu.gpa && <span className="text-gray-600"> • GPA: {edu.gpa}</span>}</p></div>)}</div></div>}
+      {certifications.length > 0 && <div className="mb-10"><h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">Certifications</h3><div className="space-y-2">{certifications.map((cert, index) => <div key={cert.id || index}><h4 className="font-medium text-gray-900">{cert.name}</h4><p className="text-sm text-gray-700 font-light">{cert.issuer}{cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}{cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}{cert.credentialId && <span> • ID: {cert.credentialId}</span>}</p></div>)}</div></div>}
+      <ResumeAdditionalSections projects={projects} variant="minimal" />
 
-      {/* Work Experience */}
-      {sortedExperiences.length > 0 && (
-        <div className="mb-10">
-          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-            Experience
-          </h3>
-          <div className="space-y-6">
-            {sortedExperiences.map((exp, index) => (
-              <div key={exp.id || index}>
-                <div className="flex justify-between items-baseline mb-1">
-                  <h4 className="text-lg font-medium text-gray-900">{exp.position}</h4>
-                  <span className="text-sm text-gray-600 font-light">
-                    {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
-                  </span>
-                </div>
-                <div className="flex justify-between items-baseline mb-2">
-                  <p className="text-gray-700 font-light">
-                    {exp.company}
-                    {exp.location && <span className="text-gray-500"> • {exp.location}</span>}
-                  </p>
-                  <span className="text-sm text-gray-500 font-light">
-                    {calculateDuration(exp.startDate, exp.endDate, exp.current)}
-                  </span>
-                </div>
-
-                {exp.description && (
-                  <p className="text-gray-700 mb-2 leading-relaxed font-light">
-                    {exp.description}
-                  </p>
-                )}
-
-                {exp.skills && exp.skills.length > 0 && (
-                  <p className="text-sm text-gray-600 mb-2 italic font-light">
-                    {exp.skills.join(', ')}
-                  </p>
-                )}
-
-                {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && (
-                  <ul className="space-y-1 text-gray-700 font-light">
-                    {exp.achievements.map((achievement, i) => (
-                      achievement && (
-                        <li key={i} className="flex items-start">
-                          <span className="mr-2">—</span>
-                          <span>{achievement}</span>
-                        </li>
-                      )
-                    ))}
-                  </ul>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Education */}
-      {education.length > 0 && (
-        <div className="mb-10">
-          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-            Education
-          </h3>
-          <div className="space-y-4">
-            {education.map((edu, index) => (
-              <div key={index}>
-                <div className="flex justify-between items-baseline">
-                  <h4 className="text-lg font-medium text-gray-900">{edu.degree}</h4>
-                  <span className="text-sm text-gray-600 font-light">
-                    {edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
-                  </span>
-                </div>
-                <p className="text-gray-700 font-light">
-                  {edu.institution}
-                  {edu.gpa && <span className="text-gray-600"> • GPA: {edu.gpa}</span>}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Certifications */}
-      {certifications.length > 0 && (
-        <div className="mb-10">
-          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
-            Certifications
-          </h3>
-          <div className="space-y-2">
-            {certifications.map((cert, index) => (
-              <div key={index}>
-                <h4 className="font-medium text-gray-900">{cert.name}</h4>
-                <p className="text-sm text-gray-700 font-light">
-                  {cert.issuer}
-                  {cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}
-                  {cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Footer */}
-      {sortedExperiences.length === 0 && !profile.summary && (
-        <div className="text-center text-gray-400 py-12">
-          <p className="font-light">Add your profile information and work experiences to generate your resume.</p>
-        </div>
-      )}
+      {sortedExperiences.length === 0 && !profile.summary && !projects.length && <div className="text-center text-gray-400 py-12"><p className="font-light">Add your profile information and work experiences to generate your resume.</p></div>}
     </div>
   );
 });
 
 MinimalTemplate.displayName = 'MinimalTemplate';
-
 export default MinimalTemplate;

--- a/src/components/resume/templates/ModernTemplateV2.js
+++ b/src/components/resume/templates/ModernTemplateV2.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ModernTemplate from './ModernTemplate';
+import ResumeAdditionalSections from '../ResumeAdditionalSections';
+
+const ModernTemplateV2 = React.forwardRef(({ profile, experiences, education = [], certifications = [], projects = [] }, ref) => (
+  <div ref={ref} className="bg-white max-w-4xl mx-auto">
+    <ModernTemplate profile={profile} experiences={experiences} education={education} certifications={certifications} />
+    <div className="px-12 pb-12">
+      <ResumeAdditionalSections projects={projects} variant="modern" />
+    </div>
+  </div>
+));
+
+ModernTemplateV2.displayName = 'ModernTemplateV2';
+export default ModernTemplateV2;

--- a/src/hooks/useResumeSections.js
+++ b/src/hooks/useResumeSections.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'resume_sections_data';
+
+const DEFAULT_DATA = {
+  education: [],
+  certifications: [],
+  projects: []
+};
+
+const normalize = (data) => ({
+  education: Array.isArray(data?.education) ? data.education : [],
+  certifications: Array.isArray(data?.certifications) ? data.certifications : [],
+  projects: Array.isArray(data?.projects) ? data.projects : []
+});
+
+const useResumeSections = () => {
+  const [sections, setSections] = useState(DEFAULT_DATA);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) setSections(normalize(JSON.parse(stored)));
+    } catch (error) {
+      console.error('Failed to load resume sections:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(sections));
+    } catch (error) {
+      console.error('Failed to save resume sections:', error);
+    }
+  }, [sections]);
+
+  const updateSections = (updates) => {
+    setSections((current) => ({ ...current, ...updates }));
+  };
+
+  const clearSections = () => {
+    setSections(DEFAULT_DATA);
+    localStorage.removeItem(STORAGE_KEY);
+  };
+
+  return { ...sections, updateSections, clearSections };
+};
+
+export default useResumeSections;

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -1,11 +1,13 @@
-import React, { useState, useRef } from 'react';
-import { FileText, Download, Edit, Eye, Printer, Layout } from 'lucide-react';
+import React, { useRef, useState } from 'react';
+import { Download, Edit, Eye, FileText, Layout, Printer } from 'lucide-react';
 import { useReactToPrint } from 'react-to-print';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import useProfile from '../hooks/useProfile';
 import useExperience from '../hooks/useExperience';
+import useResumeSections from '../hooks/useResumeSections';
 import ProfileForm from '../components/forms/ProfileForm';
+import ResumeSectionsForm from '../components/forms/ResumeSectionsForm';
 import ClassicTemplate from '../components/resume/templates/ClassicTemplate';
 import ModernTemplate from '../components/resume/templates/ModernTemplate';
 import MinimalTemplate from '../components/resume/templates/MinimalTemplate';
@@ -20,89 +22,74 @@ const TEMPLATES = [
 const Resume = () => {
   const { profile, updateProfile } = useProfile();
   const { experiences } = useExperience();
+  const { education, certifications, projects, updateSections } = useResumeSections();
   const [showProfileForm, setShowProfileForm] = useState(false);
+  const [showSectionsForm, setShowSectionsForm] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState('classic');
   const [isExporting, setIsExporting] = useState(false);
   const resumeRef = useRef(null);
+
+  const hasProfile = Boolean(profile.fullName || profile.email);
+  const currentTemplate = TEMPLATES.find((template) => template.id === selectedTemplate) || TEMPLATES[0];
+  const TemplateComponent = currentTemplate.component;
 
   const handleProfileUpdate = (updatedProfile) => {
     updateProfile(updatedProfile);
     setShowProfileForm(false);
   };
 
-  // Print handler
   const handlePrint = useReactToPrint({
     content: () => resumeRef.current,
     documentTitle: `Resume_${profile.fullName || 'MyResume'}`,
   });
 
-  // PDF export handler using html2canvas + jsPDF
   const handleDownloadPDF = async () => {
     if (!resumeRef.current) return;
-
     setIsExporting(true);
     try {
-      // Capture the resume as canvas
       const canvas = await html2canvas(resumeRef.current, {
-        scale: 2, // Higher quality
+        scale: 2,
         useCORS: true,
         logging: false,
         backgroundColor: '#ffffff',
       });
-
-      // Calculate dimensions for US Letter size PDF
-      const imgWidth = 210; // A4 width in mm
-      const pageHeight = 297; // A4 height in mm
-      const imgHeight = (canvas.height * imgWidth) / canvas.width;
-      let heightLeft = imgHeight;
-
+      const pageWidth = 210;
+      const pageHeight = 297;
+      const imageHeight = (canvas.height * pageWidth) / canvas.width;
       const pdf = new jsPDF('p', 'mm', 'a4');
-      let position = 0;
+      const image = canvas.toDataURL('image/png');
+      let remaining = imageHeight;
+      let offset = 0;
 
-      // Add image to PDF
-      const imgData = canvas.toDataURL('image/png');
-      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
-      heightLeft -= pageHeight;
-
-      // Add new pages if content exceeds one page
-      while (heightLeft >= 0) {
-        position = heightLeft - imgHeight;
-        pdf.addPage();
-        pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
-        heightLeft -= pageHeight;
+      while (remaining > 0) {
+        pdf.addImage(image, 'PNG', 0, offset, pageWidth, imageHeight);
+        remaining -= pageHeight;
+        if (remaining > 0) {
+          pdf.addPage();
+          offset = -(imageHeight - remaining);
+        }
       }
 
-      // Download the PDF
       pdf.save(`Resume_${profile.fullName || 'MyResume'}_${new Date().toISOString().split('T')[0]}.pdf`);
     } catch (error) {
       console.error('Error generating PDF:', error);
-      alert('Failed to generate PDF. Please try printing instead.');
+      window.alert('Failed to generate PDF. Please try printing instead.');
     } finally {
       setIsExporting(false);
     }
   };
 
-  const hasProfile = profile.fullName || profile.email;
-  const currentTemplate = TEMPLATES.find(t => t.id === selectedTemplate) || TEMPLATES[0];
-  const TemplateComponent = currentTemplate.component;
-
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 py-12 px-4">
       <div className="max-w-6xl mx-auto">
-        {/* Header */}
-        <div className="text-center mb-12">
+        <div className="text-center mb-10">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-linkedin-600 rounded-full mb-4">
             <FileText className="w-8 h-8 text-white" />
           </div>
-          <h1 className="text-4xl font-bold text-gray-800 dark:text-white mb-2">
-            Resume Builder
-          </h1>
-          <p className="text-gray-600 dark:text-gray-300">
-            Create a professional resume from your work experiences
-          </p>
+          <h1 className="text-4xl font-bold text-gray-800 dark:text-white mb-2">Resume Builder</h1>
+          <p className="text-gray-600 dark:text-gray-300">Build, preview and export a complete professional resume.</p>
         </div>
 
-        {/* Template Selector */}
         <div className="mb-8">
           <div className="flex items-center justify-center mb-4">
             <Layout className="w-5 h-5 text-gray-600 dark:text-gray-300 mr-2" />
@@ -113,11 +100,7 @@ const Resume = () => {
               <button
                 key={template.id}
                 onClick={() => setSelectedTemplate(template.id)}
-                className={`px-6 py-3 rounded-lg border-2 transition-all duration-200 ${
-                  selectedTemplate === template.id
-                    ? 'border-linkedin-600 bg-linkedin-50 dark:bg-linkedin-900/20 text-linkedin-700 dark:text-linkedin-400'
-                    : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 hover:border-linkedin-400'
-                }`}
+                className={`px-6 py-3 rounded-lg border-2 transition-all duration-200 ${selectedTemplate === template.id ? 'border-linkedin-600 bg-linkedin-50 dark:bg-linkedin-900/20 text-linkedin-700 dark:text-linkedin-400' : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 hover:border-linkedin-400'}`}
               >
                 <div className="font-semibold">{template.name}</div>
                 <div className="text-xs mt-1 opacity-75">{template.description}</div>
@@ -126,23 +109,18 @@ const Resume = () => {
           </div>
         </div>
 
-        {/* Action Buttons */}
         <div className="flex flex-wrap justify-center gap-4 mb-8">
-          <Button
-            onClick={() => setShowProfileForm(!showProfileForm)}
-            variant={showProfileForm ? 'secondary' : 'primary'}
-          >
+          <Button onClick={() => setShowProfileForm((value) => !value)} variant={showProfileForm ? 'secondary' : 'primary'}>
             <Edit className="w-4 h-4 mr-2" />
             {hasProfile ? 'Edit Profile' : 'Add Profile Info'}
           </Button>
-          
+          <Button onClick={() => setShowSectionsForm((value) => !value)} variant={showSectionsForm ? 'secondary' : 'primary'}>
+            <Layout className="w-4 h-4 mr-2" />
+            {showSectionsForm ? 'Hide Resume Sections' : 'Add Resume Sections'}
+          </Button>
           {hasProfile && (
             <>
-              <Button 
-                onClick={handleDownloadPDF} 
-                variant="primary"
-                disabled={isExporting}
-              >
+              <Button onClick={handleDownloadPDF} variant="primary" disabled={isExporting}>
                 <Download className="w-4 h-4 mr-2" />
                 {isExporting ? 'Generating PDF...' : 'Download PDF'}
               </Button>
@@ -154,40 +132,33 @@ const Resume = () => {
           )}
         </div>
 
-        {/* Profile Form */}
-        {showProfileForm && (
-          <ProfileForm
-            profile={profile}
-            onUpdate={handleProfileUpdate}
-            onCancel={() => setShowProfileForm(false)}
+        {showProfileForm && <ProfileForm profile={profile} onUpdate={handleProfileUpdate} onCancel={() => setShowProfileForm(false)} />}
+        {showSectionsForm && (
+          <ResumeSectionsForm
+            education={education}
+            certifications={certifications}
+            projects={projects}
+            onChange={(key, value) => updateSections({ [key]: value })}
           />
         )}
 
-        {/* Resume Preview */}
         <div className="print:shadow-none bg-white dark:bg-slate-800 rounded-2xl shadow-2xl overflow-hidden">
           <TemplateComponent
             ref={resumeRef}
             profile={profile}
             experiences={experiences}
-            education={[]} // TODO: Add education data when implemented
-            certifications={[]} // TODO: Add certifications data when implemented
+            education={education}
+            certifications={certifications}
+            projects={projects}
           />
         </div>
 
-        {/* Empty State */}
         {!hasProfile && !showProfileForm && (
           <div className="text-center mt-12 p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-xl">
             <Eye className="w-16 h-16 mx-auto text-gray-400 mb-4" />
-            <h3 className="text-xl font-bold text-gray-800 dark:text-white mb-2">
-              Get Started
-            </h3>
-            <p className="text-gray-600 dark:text-gray-300 mb-6">
-              Add your profile information to see your resume preview
-            </p>
-            <Button onClick={() => setShowProfileForm(true)}>
-              <Edit className="w-4 h-4 mr-2" />
-              Add Profile Info
-            </Button>
+            <h3 className="text-xl font-bold text-gray-800 dark:text-white mb-2">Get Started</h3>
+            <p className="text-gray-600 dark:text-gray-300 mb-6">Add your profile information to see your resume preview.</p>
+            <Button onClick={() => setShowProfileForm(true)}><Edit className="w-4 h-4 mr-2" />Add Profile Info</Button>
           </div>
         )}
       </div>

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -8,8 +8,8 @@ import useExperience from '../hooks/useExperience';
 import useResumeSections from '../hooks/useResumeSections';
 import ProfileForm from '../components/forms/ProfileForm';
 import ResumeSectionsForm from '../components/forms/ResumeSectionsForm';
-import ClassicTemplate from '../components/resume/templates/ClassicTemplate';
-import ModernTemplate from '../components/resume/templates/ModernTemplate';
+import ClassicTemplate from '../components/resume/templates/ClassicTemplateV2';
+import ModernTemplate from '../components/resume/templates/ModernTemplateV2';
 import MinimalTemplate from '../components/resume/templates/MinimalTemplate';
 import Button from '../components/common/Button';
 
@@ -28,31 +28,18 @@ const Resume = () => {
   const [selectedTemplate, setSelectedTemplate] = useState('classic');
   const [isExporting, setIsExporting] = useState(false);
   const resumeRef = useRef(null);
-
   const hasProfile = Boolean(profile.fullName || profile.email);
   const currentTemplate = TEMPLATES.find((template) => template.id === selectedTemplate) || TEMPLATES[0];
   const TemplateComponent = currentTemplate.component;
 
-  const handleProfileUpdate = (updatedProfile) => {
-    updateProfile(updatedProfile);
-    setShowProfileForm(false);
-  };
-
-  const handlePrint = useReactToPrint({
-    content: () => resumeRef.current,
-    documentTitle: `Resume_${profile.fullName || 'MyResume'}`,
-  });
+  const handleProfileUpdate = (updatedProfile) => { updateProfile(updatedProfile); setShowProfileForm(false); };
+  const handlePrint = useReactToPrint({ content: () => resumeRef.current, documentTitle: `Resume_${profile.fullName || 'MyResume'}` });
 
   const handleDownloadPDF = async () => {
     if (!resumeRef.current) return;
     setIsExporting(true);
     try {
-      const canvas = await html2canvas(resumeRef.current, {
-        scale: 2,
-        useCORS: true,
-        logging: false,
-        backgroundColor: '#ffffff',
-      });
+      const canvas = await html2canvas(resumeRef.current, { scale: 2, useCORS: true, logging: false, backgroundColor: '#ffffff' });
       const pageWidth = 210;
       const pageHeight = 297;
       const imageHeight = (canvas.height * pageWidth) / canvas.width;
@@ -60,107 +47,36 @@ const Resume = () => {
       const image = canvas.toDataURL('image/png');
       let remaining = imageHeight;
       let offset = 0;
-
       while (remaining > 0) {
         pdf.addImage(image, 'PNG', 0, offset, pageWidth, imageHeight);
         remaining -= pageHeight;
-        if (remaining > 0) {
-          pdf.addPage();
-          offset = -(imageHeight - remaining);
-        }
+        if (remaining > 0) { pdf.addPage(); offset = -(imageHeight - remaining); }
       }
-
       pdf.save(`Resume_${profile.fullName || 'MyResume'}_${new Date().toISOString().split('T')[0]}.pdf`);
     } catch (error) {
       console.error('Error generating PDF:', error);
       window.alert('Failed to generate PDF. Please try printing instead.');
-    } finally {
-      setIsExporting(false);
-    }
+    } finally { setIsExporting(false); }
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 py-12 px-4">
       <div className="max-w-6xl mx-auto">
-        <div className="text-center mb-10">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-linkedin-600 rounded-full mb-4">
-            <FileText className="w-8 h-8 text-white" />
-          </div>
-          <h1 className="text-4xl font-bold text-gray-800 dark:text-white mb-2">Resume Builder</h1>
-          <p className="text-gray-600 dark:text-gray-300">Build, preview and export a complete professional resume.</p>
-        </div>
-
-        <div className="mb-8">
-          <div className="flex items-center justify-center mb-4">
-            <Layout className="w-5 h-5 text-gray-600 dark:text-gray-300 mr-2" />
-            <h2 className="text-lg font-semibold text-gray-800 dark:text-white">Choose Template</h2>
-          </div>
-          <div className="flex flex-wrap justify-center gap-4">
-            {TEMPLATES.map((template) => (
-              <button
-                key={template.id}
-                onClick={() => setSelectedTemplate(template.id)}
-                className={`px-6 py-3 rounded-lg border-2 transition-all duration-200 ${selectedTemplate === template.id ? 'border-linkedin-600 bg-linkedin-50 dark:bg-linkedin-900/20 text-linkedin-700 dark:text-linkedin-400' : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 hover:border-linkedin-400'}`}
-              >
-                <div className="font-semibold">{template.name}</div>
-                <div className="text-xs mt-1 opacity-75">{template.description}</div>
-              </button>
-            ))}
-          </div>
-        </div>
+        <div className="text-center mb-10"><div className="inline-flex items-center justify-center w-16 h-16 bg-linkedin-600 rounded-full mb-4"><FileText className="w-8 h-8 text-white" /></div><h1 className="text-4xl font-bold text-gray-800 dark:text-white mb-2">Resume Builder</h1><p className="text-gray-600 dark:text-gray-300">Build, preview and export a complete professional resume.</p></div>
+        <div className="mb-8"><div className="flex items-center justify-center mb-4"><Layout className="w-5 h-5 text-gray-600 dark:text-gray-300 mr-2" /><h2 className="text-lg font-semibold text-gray-800 dark:text-white">Choose Template</h2></div><div className="flex flex-wrap justify-center gap-4">{TEMPLATES.map((template) => <button key={template.id} onClick={() => setSelectedTemplate(template.id)} className={`px-6 py-3 rounded-lg border-2 transition-all duration-200 ${selectedTemplate === template.id ? 'border-linkedin-600 bg-linkedin-50 dark:bg-linkedin-900/20 text-linkedin-700 dark:text-linkedin-400' : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-300 hover:border-linkedin-400'}`}><div className="font-semibold">{template.name}</div><div className="text-xs mt-1 opacity-75">{template.description}</div></button>)}</div></div>
 
         <div className="flex flex-wrap justify-center gap-4 mb-8">
-          <Button onClick={() => setShowProfileForm((value) => !value)} variant={showProfileForm ? 'secondary' : 'primary'}>
-            <Edit className="w-4 h-4 mr-2" />
-            {hasProfile ? 'Edit Profile' : 'Add Profile Info'}
-          </Button>
-          <Button onClick={() => setShowSectionsForm((value) => !value)} variant={showSectionsForm ? 'secondary' : 'primary'}>
-            <Layout className="w-4 h-4 mr-2" />
-            {showSectionsForm ? 'Hide Resume Sections' : 'Add Resume Sections'}
-          </Button>
-          {hasProfile && (
-            <>
-              <Button onClick={handleDownloadPDF} variant="primary" disabled={isExporting}>
-                <Download className="w-4 h-4 mr-2" />
-                {isExporting ? 'Generating PDF...' : 'Download PDF'}
-              </Button>
-              <Button onClick={handlePrint} variant="secondary">
-                <Printer className="w-4 h-4 mr-2" />
-                Print
-              </Button>
-            </>
-          )}
+          <Button onClick={() => setShowProfileForm((value) => !value)} variant={showProfileForm ? 'secondary' : 'primary'}><Edit className="w-4 h-4 mr-2" />{hasProfile ? 'Edit Profile' : 'Add Profile Info'}</Button>
+          <Button onClick={() => setShowSectionsForm((value) => !value)} variant={showSectionsForm ? 'secondary' : 'primary'}><Layout className="w-4 h-4 mr-2" />{showSectionsForm ? 'Hide Resume Sections' : 'Add Resume Sections'}</Button>
+          {hasProfile && <><Button onClick={handleDownloadPDF} variant="primary" disabled={isExporting}><Download className="w-4 h-4 mr-2" />{isExporting ? 'Generating PDF...' : 'Download PDF'}</Button><Button onClick={handlePrint} variant="secondary"><Printer className="w-4 h-4 mr-2" />Print</Button></>}
         </div>
 
         {showProfileForm && <ProfileForm profile={profile} onUpdate={handleProfileUpdate} onCancel={() => setShowProfileForm(false)} />}
-        {showSectionsForm && (
-          <ResumeSectionsForm
-            education={education}
-            certifications={certifications}
-            projects={projects}
-            onChange={(key, value) => updateSections({ [key]: value })}
-          />
-        )}
+        {showSectionsForm && <ResumeSectionsForm education={education} certifications={certifications} projects={projects} onChange={(key, value) => updateSections({ [key]: value })} />}
 
-        <div className="print:shadow-none bg-white dark:bg-slate-800 rounded-2xl shadow-2xl overflow-hidden">
-          <TemplateComponent
-            ref={resumeRef}
-            profile={profile}
-            experiences={experiences}
-            education={education}
-            certifications={certifications}
-            projects={projects}
-          />
-        </div>
+        <div className="print:shadow-none bg-white dark:bg-slate-800 rounded-2xl shadow-2xl overflow-hidden"><TemplateComponent ref={resumeRef} profile={profile} experiences={experiences} education={education} certifications={certifications} projects={projects} /></div>
 
-        {!hasProfile && !showProfileForm && (
-          <div className="text-center mt-12 p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-xl">
-            <Eye className="w-16 h-16 mx-auto text-gray-400 mb-4" />
-            <h3 className="text-xl font-bold text-gray-800 dark:text-white mb-2">Get Started</h3>
-            <p className="text-gray-600 dark:text-gray-300 mb-6">Add your profile information to see your resume preview.</p>
-            <Button onClick={() => setShowProfileForm(true)}><Edit className="w-4 h-4 mr-2" />Add Profile Info</Button>
-          </div>
-        )}
+        {!hasProfile && !showProfileForm && <div className="text-center mt-12 p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-xl"><Eye className="w-16 h-16 mx-auto text-gray-400 mb-4" /><h3 className="text-xl font-bold text-gray-800 dark:text-white mb-2">Get Started</h3><p className="text-gray-600 dark:text-gray-300 mb-6">Add your profile information to see your resume preview.</p><Button onClick={() => setShowProfileForm(true)}><Edit className="w-4 h-4 mr-2" />Add Profile Info</Button></div>}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
- Added persistent Education, Certifications, and Projects sections.
- Added a dedicated Resume Sections editor with add/remove controls.
- Connected section data to resume preview and localStorage.
- Added project rendering to all resume templates.
- Improved multi-page PDF export handling.
- Added component tests for the new resume section editor.

## Why
The existing builder had template support for education/certifications but no user-facing data model or editor, and projects were missing entirely. This completes the next Resume Builder milestone before the AI tailoring phase.

## Validation
- GitHub Actions will run the full Jest suite, production build, and GitHub Pages deployment on merge to main.
- New tests cover rendering and adding education, certification, and project entries.