### PR TITLE
test: add browser UI regression gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,28 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: Update package-lock.json"
           git push
 
-      - name: Run tests
-        run: npm test -- --coverage
+      - name: Run unit tests
+        run: npm test -- --coverage --watchAll=false
 
       - name: Build project
         run: npm run build
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser UI regression tests
+        run: npm run test:e2e
+
+      - name: Upload browser test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-ui-test-artifacts
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -1,0 +1,112 @@
+const { test, expect } = require('@playwright/test');
+
+const profile = {
+  fullName: 'Alex Engineer',
+  headline: 'Senior Software Engineer',
+  email: 'alex@example.com',
+  phone: '+91 99999 99999',
+  location: 'Bengaluru, India',
+  linkedin: 'https://linkedin.com/in/alexengineer',
+  website: 'https://example.com',
+  summary: 'Senior engineer building reliable developer platforms and scalable products.'
+};
+
+async function openResume(page) {
+  await page.goto('/resume');
+  await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+}
+
+async function addProfile(page) {
+  await page.getByRole('button', { name: /add profile info/i }).click();
+  await page.getByLabel('Full Name').fill(profile.fullName);
+  await page.getByLabel('Professional Headline').fill(profile.headline);
+  await page.getByLabel('Email').fill(profile.email);
+  await page.getByLabel('Phone').fill(profile.phone);
+  await page.getByLabel('Location').fill(profile.location);
+  await page.getByLabel('LinkedIn URL').fill(profile.linkedin);
+  await page.getByLabel('Website / Portfolio').fill(profile.website);
+  await page.getByLabel('Professional Summary').fill(profile.summary);
+  await page.getByRole('button', { name: 'Save Profile' }).click();
+  await expect(page.getByRole('button', { name: /edit profile/i })).toBeVisible();
+}
+
+async function addAllSections(page) {
+  await page.getByRole('button', { name: /add education/i }).click();
+  await page.getByLabel('Degree').fill('B.Tech in Computer Science');
+  await page.getByLabel('Institution').fill('Example Institute of Technology');
+  await page.getByLabel('Location').fill('Bengaluru, India');
+  await page.getByLabel('GPA / Grade').fill('8.8/10');
+  await page.getByLabel('Start Year').fill('2017');
+  await page.getByLabel('End / Graduation Year').fill('2021');
+
+  await page.getByRole('button', { name: /add certification/i }).click();
+  await page.getByLabel('Certification').fill('AWS Certified Developer');
+  await page.getByLabel('Issuing Organization').fill('Amazon Web Services');
+  await page.getByLabel('Credential ID').fill('AWS-12345');
+
+  await page.getByRole('button', { name: /add project/i }).click();
+  await page.getByLabel('Project Name').fill('Developer Platform');
+  await page.getByLabel('Technologies').fill('React, Node.js, AWS');
+  await page.getByLabel('Project URL').fill('https://example.com/project');
+  await page.getByLabel('GitHub URL').fill('https://github.com/example/project');
+  await page.getByLabel('Description').fill('Built a developer platform that reduced deployment friction and improved release reliability.');
+}
+
+function assertNoHorizontalOverflow(page) {
+  return page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1);
+}
+
+test.describe('Resume Builder browser regression', () => {
+  test.beforeEach(async ({ page }) => {
+    await openResume(page);
+  });
+
+  test('desktop builder supports profile, all sections, templates, persistence and PDF export', async ({ page }) => {
+    await addProfile(page);
+    await addAllSections(page);
+
+    await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
+    await expect(page.getByText('AWS Certified Developer')).toBeVisible();
+    await expect(page.getByText('Developer Platform')).toBeVisible();
+
+    for (const template of ['Classic', 'Modern', 'Minimal']) {
+      await page.getByRole('button', { name: new RegExp(`^${template}`) }).click();
+      await expect(page.getByText('Alex Engineer')).toBeVisible();
+      await expect(page.getByText('Developer Platform')).toBeVisible();
+      await expect(page.locator('[data-testid="resume-preview"]')).toBeVisible();
+    }
+
+    expect(await assertNoHorizontalOverflow(page)).toBeTruthy();
+
+    await page.reload();
+    await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
+    await expect(page.getByText('AWS Certified Developer')).toBeVisible();
+    await expect(page.getByText('Developer Platform')).toBeVisible();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /download pdf/i }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/Resume_Alex Engineer_\d{4}-\d{2}-\d{2}\.pdf/);
+
+    await page.screenshot({ path: 'test-results/resume-desktop-full.png', fullPage: true });
+  });
+
+  test('desktop dark mode keeps the builder readable and within viewport', async ({ page }) => {
+    await page.evaluate(() => document.documentElement.classList.add('dark'));
+    await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
+    expect(await assertNoHorizontalOverflow(page)).toBeTruthy();
+    await page.screenshot({ path: 'test-results/resume-desktop-dark.png', fullPage: true });
+  });
+
+  test('mobile layout has no horizontal overflow and exposes all key controls', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
+    await expect(page.getByRole('button', { name: /add profile info/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Classic/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Modern/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Minimal/ })).toBeVisible();
+    expect(await assertNoHorizontalOverflow(page)).toBeTruthy();
+    await page.screenshot({ path: 'test-results/resume-mobile.png', fullPage: true });
+  });
+});

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -33,6 +33,7 @@ async function addProfile(page) {
 }
 
 async function addAllSections(page) {
+  await page.getByRole('button', { name: /add resume sections/i }).click();
   await page.getByRole('button', { name: /add education/i }).click();
   await page.getByLabel('Degree').fill('B.Tech in Computer Science');
   await page.getByLabel('Institution').fill('Example Institute of Technology');
@@ -63,7 +64,8 @@ test.describe('Resume Builder browser regression', () => {
     await openResume(page);
   });
 
-  test('desktop builder supports profile, all sections, templates, persistence and PDF export', async ({ page }) => {
+  test('desktop builder supports profile, all sections, templates, persistence and PDF export', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'chromium-desktop', 'Desktop-only workflow');
     await addProfile(page);
     await addAllSections(page);
 
@@ -90,23 +92,25 @@ test.describe('Resume Builder browser regression', () => {
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toMatch(/Resume_Alex Engineer_\d{4}-\d{2}-\d{2}\.pdf/);
 
-    await page.screenshot({ path: 'test-results/resume-desktop-full.png', fullPage: true });
+    await page.screenshot({ path: testInfo.outputPath('resume-desktop-full.png'), fullPage: true });
   });
 
-  test('desktop dark mode keeps the builder readable and within viewport', async ({ page }) => {
+  test('desktop dark mode keeps the builder readable and within viewport', async ({ page, testInfo }) => {
+    test.skip(testInfo.project.name !== 'chromium-desktop', 'Desktop-only workflow');
     await page.evaluate(() => document.documentElement.classList.add('dark'));
     await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
     expect(await assertNoHorizontalOverflow(page)).toBeTruthy();
-    await page.screenshot({ path: 'test-results/resume-desktop-dark.png', fullPage: true });
+    await page.screenshot({ path: testInfo.outputPath('resume-desktop-dark.png'), fullPage: true });
   });
 
-  test('mobile layout has no horizontal overflow and exposes all key controls', async ({ page }) => {
+  test('mobile layout has no horizontal overflow and exposes all key controls', async ({ page, testInfo }) => {
+    test.skip(testInfo.project.name !== 'chromium-mobile', 'Mobile-only workflow');
     await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
     await expect(page.getByRole('button', { name: /add profile info/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Classic/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Modern/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Minimal/ })).toBeVisible();
     expect(await assertNoHorizontalOverflow(page)).toBeTruthy();
-    await page.screenshot({ path: 'test-results/resume-mobile.png', fullPage: true });
+    await page.screenshot({ path: testInfo.outputPath('resume-mobile.png'), fullPage: true });
   });
 });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:e2e": "playwright test",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
@@ -46,6 +47,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,34 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  timeout: 45_000,
+  expect: { timeout: 8_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  use: {
+    baseURL: 'http://127.0.0.1:4173/work-exp-app',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npx serve -s build -l 4173',
+    url: 'http://127.0.0.1:4173/work-exp-app/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 1000 } },
+    },
+    {
+      name: 'chromium-mobile',
+      use: { ...devices['iPhone 13'] },
+    },
+  ],
+});

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -74,7 +74,7 @@ const Resume = () => {
         {showProfileForm && <ProfileForm profile={profile} onUpdate={handleProfileUpdate} onCancel={() => setShowProfileForm(false)} />}
         {showSectionsForm && <ResumeSectionsForm education={education} certifications={certifications} projects={projects} onChange={(key, value) => updateSections({ [key]: value })} />}
 
-        <div className="print:shadow-none bg-white dark:bg-slate-800 rounded-2xl shadow-2xl overflow-hidden"><TemplateComponent ref={resumeRef} profile={profile} experiences={experiences} education={education} certifications={certifications} projects={projects} /></div>
+        <div data-testid="resume-preview" className="print:shadow-none bg-white dark:bg-slate-800 rounded-2xl shadow-2xl overflow-hidden"><TemplateComponent ref={resumeRef} profile={profile} experiences={experiences} education={education} certifications={certifications} projects={projects} /></div>
 
         {!hasProfile && !showProfileForm && <div className="text-center mt-12 p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-xl"><Eye className="w-16 h-16 mx-auto text-gray-400 mb-4" /><h3 className="text-xl font-bold text-gray-800 dark:text-white mb-2">Get Started</h3><p className="text-gray-600 dark:text-gray-300 mb-6">Add your profile information to see your resume preview.</p><Button onClick={() => setShowProfileForm(true)}><Edit className="w-4 h-4 mr-2" />Add Profile Info</Button></div>}
       </div>


### PR DESCRIPTION
Adds Playwright Chromium regression coverage to the deployment pipeline. The suite checks the Resume Builder end-to-end flow, Education/Certifications/Projects, all three templates, persistence after reload, PDF download, dark-mode layout, mobile layout, and horizontal overflow. Screenshots are retained as CI artifacts for visual inspection. Deployment remains gated behind unit tests, build, and browser tests.