### PR TITLE
fix: make Playwright CI work with GitHub Pages basename

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-test-deploy:
@@ -16,17 +19,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
-
-      - name: Commit updated package-lock.json
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add package-lock.json
-          git diff --staged --quiet || git commit -m "chore: Update package-lock.json"
-          git push
+        run: npm ci
 
       - name: Run unit tests
         run: npm test -- --coverage --watchAll=false
@@ -52,6 +48,7 @@ jobs:
           retention-days: 14
 
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -61,7 +61,7 @@ async function addAllSections(page) {
   await page.getByLabel('Technologies').fill('React, Node.js, AWS');
   await page.getByLabel('Project URL').fill('https://example.com/project');
   await page.getByLabel('GitHub URL').fill('https://github.com/example/project');
-  await page.getByLabel('Description').fill('Built a developer platform that reduced deployment friction and improved release reliability.');
+  await page.locator('textarea[placeholder="What did you build and what impact did it have?"]').fill('Built a developer platform that reduced deployment friction and improved release reliability.');
 }
 
 function assertNoHorizontalOverflow(page) {

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -28,7 +28,7 @@ async function openResume(page) {
 }
 
 async function addProfile(page) {
-  await page.getByRole('button', { name: /add profile info/i }).click();
+  await page.getByRole('button', { name: 'Add Profile Info', exact: true }).first().click();
   await page.getByLabel('Full Name').fill(profile.fullName);
   await page.getByLabel('Professional Headline').fill(profile.headline);
   await page.getByLabel('Email').fill(profile.email);
@@ -115,7 +115,7 @@ test.describe('Resume Builder browser regression', () => {
   test('mobile layout has no horizontal overflow and exposes all key controls', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'chromium-mobile', 'Mobile-only workflow');
     await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
-    await expect(page.getByRole('button', { name: /add profile info/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add Profile Info', exact: true }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /^Classic/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Modern/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /^Minimal/ })).toBeVisible();

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -12,10 +12,16 @@ const profile = {
 };
 
 async function openResume(page) {
-  const response = await page.goto('/work-exp-app/resume', { waitUntil: 'domcontentloaded' });
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error));
+
+  const response = await page.goto('./resume', { waitUntil: 'domcontentloaded' });
   expect(response).not.toBeNull();
   expect(response.status()).toBeLessThan(400);
+
   await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();
+  expect(pageErrors, pageErrors.map((error) => error.stack || error.message).join('\n')).toHaveLength(0);
+
   await page.evaluate(() => localStorage.clear());
   await page.reload({ waitUntil: 'domcontentloaded' });
   await expect(page.getByRole('heading', { name: 'Resume Builder' })).toBeVisible();

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -68,6 +68,8 @@ function assertNoHorizontalOverflow(page) {
   return page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1);
 }
 
+const preview = (page) => page.getByTestId('resume-preview');
+
 test.describe('Resume Builder browser regression', () => {
   test.beforeEach(async ({ page }) => {
     await openResume(page);
@@ -80,13 +82,13 @@ test.describe('Resume Builder browser regression', () => {
 
     await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
     await expect(page.getByText('AWS Certified Developer')).toBeVisible();
-    await expect(page.getByText('Developer Platform')).toBeVisible();
+    await expect(preview(page).getByRole('heading', { name: 'Developer Platform' })).toBeVisible();
 
     for (const template of ['Classic', 'Modern', 'Minimal']) {
       await page.getByRole('button', { name: new RegExp(`^${template}`) }).click();
-      await expect(page.getByText('Alex Engineer')).toBeVisible();
-      await expect(page.getByText('Developer Platform')).toBeVisible();
-      await expect(page.locator('[data-testid="resume-preview"]')).toBeVisible();
+      await expect(preview(page).getByText('Alex Engineer')).toBeVisible();
+      await expect(preview(page).getByText('Developer Platform')).toBeVisible();
+      await expect(preview(page)).toBeVisible();
     }
 
     expect(await assertNoHorizontalOverflow(page)).toBeTruthy();
@@ -94,7 +96,7 @@ test.describe('Resume Builder browser regression', () => {
     await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
     await expect(page.getByText('AWS Certified Developer')).toBeVisible();
-    await expect(page.getByText('Developer Platform')).toBeVisible();
+    await expect(preview(page).getByText('Developer Platform')).toBeVisible();
 
     const downloadPromise = page.waitForEvent('download');
     await page.getByRole('button', { name: /download pdf/i }).click();

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -70,6 +70,10 @@ function assertNoHorizontalOverflow(page) {
 
 const preview = (page) => page.getByTestId('resume-preview');
 
+async function expectPreviewProject(page) {
+  await expect(preview(page).getByRole('heading', { name: 'Developer Platform' })).toBeVisible();
+}
+
 test.describe('Resume Builder browser regression', () => {
   test.beforeEach(async ({ page }) => {
     await openResume(page);
@@ -82,12 +86,12 @@ test.describe('Resume Builder browser regression', () => {
 
     await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
     await expect(page.getByText('AWS Certified Developer')).toBeVisible();
-    await expect(preview(page).getByRole('heading', { name: 'Developer Platform' })).toBeVisible();
+    await expectPreviewProject(page);
 
     for (const template of ['Classic', 'Modern', 'Minimal']) {
       await page.getByRole('button', { name: new RegExp(`^${template}`) }).click();
       await expect(preview(page).getByText('Alex Engineer')).toBeVisible();
-      await expect(preview(page).getByText('Developer Platform')).toBeVisible();
+      await expectPreviewProject(page);
       await expect(preview(page)).toBeVisible();
     }
 
@@ -96,7 +100,7 @@ test.describe('Resume Builder browser regression', () => {
     await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
     await expect(page.getByText('AWS Certified Developer')).toBeVisible();
-    await expect(preview(page).getByText('Developer Platform')).toBeVisible();
+    await expectPreviewProject(page);
 
     const downloadPromise = page.waitForEvent('download');
     await page.getByRole('button', { name: /download pdf/i }).click();

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -36,7 +36,7 @@ async function addProfile(page) {
   await page.getByLabel('Location').fill(profile.location);
   await page.getByLabel('LinkedIn URL').fill(profile.linkedin);
   await page.getByLabel('Website / Portfolio').fill(profile.website);
-  await page.getByLabel('Professional Summary').fill(profile.summary);
+  await page.locator('textarea[name="summary"]').fill(profile.summary);
   await page.getByRole('button', { name: 'Save Profile' }).click();
   await expect(page.getByRole('button', { name: /edit profile/i })).toBeVisible();
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,7 +16,7 @@ module.exports = defineConfig({
     video: 'retain-on-failure',
   },
   webServer: {
-    command: 'npx serve -s build -l 4173',
+    command: 'node e2e/server.js',
     url: 'http://127.0.0.1:4173/work-exp-app/',
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,


### PR DESCRIPTION
## Root cause

The CRA build is configured with the GitHub Pages basename `/work-exp-app`. Playwright was serving `build/` with `serve -s`, but that server treated `/work-exp-app/static/...` as a filesystem path under `build/work-exp-app/...`. The HTML shell returned successfully, but the JavaScript bundles were not served from their actual `build/static/...` locations, leaving the browser on a blank page and causing `Resume Builder` to never render.

## Fix

- Add a deterministic Node SPA server for E2E tests that strips `/work-exp-app` before resolving build assets and falls back to `index.html` for React Router routes.
- Keep Playwright `baseURL` aligned with the production basename.
- Run E2E setup with `./resume` relative to that base URL.
- Surface browser runtime errors in the E2E setup.
- Run the CI workflow on pull requests.
- Replace `npm install` + automatic lockfile commits with `npm ci` so CI is deterministic and never mutates the branch.
- Only deploy to `gh-pages` on pushes to `main`.

The goal is to keep this PR open until GitHub Actions is green, then merge it into `main`.