### PR TITLE
feat: add free local job description matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,386 +1,287 @@
 # 🧰 Work Experience Tracker & Resume Builder
 
-A beautiful and intuitive React application for tracking your professional work experience and generating professional resumes. Built with modern design principles, smooth animations, and a focus on user experience.
+A privacy-first React application for tracking professional experience, building resumes, and comparing resumes against job descriptions.
+
+The project is intentionally **free and local-first**. The new Job Match feature uses a transparent rule-based engine that runs entirely in the browser — no OpenAI API, paid AI provider, backend, account, API key, or usage quota is required.
 
 ## ✨ Features
 
-### 📊 **Experience Management**
-- **Smart Experience Tracking**
-  - Real-time duration calculations (years, months, days)
-  - Company autocomplete with Clearbit API integration
-  - Job title autocomplete (300+ local titles + API suggestions)
-  - Location autocomplete (300+ major cities worldwide)
-  - Skills & technologies tracking per role
-  - Achievement management with bullet points
-  - Support for current positions
-
-### 📄 **Professional Resume Builder** ⭐ NEW
-- **Multiple Templates**
-  - **Classic** - Traditional serif design with timeline
-  - **Modern** - Contemporary with color accents and gradients
-  - **Minimal** - Clean, simple, and ATS-friendly
-- **PDF Export** - High-quality PDF generation with custom filename
-- **Print Support** - Optimized print layouts
-- **Template Switching** - Live preview with instant template changes
-- **Auto Sections** - Skills, Experience, Education, Certifications
-
-### 🎨 **Modern & Beautiful UI**
-- Clean, minimal design with gradient backgrounds
-- Smooth animations and transitions
-- Responsive layout that works on all devices
-- Dark mode support
-- Eye-friendly color scheme with professional aesthetics
-
-### 🔧 **Data Management**
-- Export/Import data as JSON
+### 📊 Experience Management
+- Real-time experience duration calculations
+- Company, role, location and employment details
+- Skills and technologies per role
+- Achievement bullets
+- Current-position support
 - LocalStorage persistence
-- Clear all data option
-- Merge or replace on import
+- JSON import/export
 
-## 📸 Screenshots
+### 📄 Resume Builder
+- Classic, Modern and Minimal templates
+- Profile and professional summary
+- Work experience
+- Technical skills aggregation
+- Education
+- Certifications
+- Projects
+- PDF export
+- Print support
+- Template switching
+- Dark mode and responsive layouts
 
-### Resume Templates
+### 🎯 Job Match — NEW
+Paste a complete job description and compare it with the career information stored in the app.
 
-**Classic Template**
-- Traditional professional design
-- Serif typography (Georgia)
-- Timeline-based experience layout
-- Black and white for maximum compatibility
+The matcher reports:
+- Overall match score
+- Required-skill coverage
+- Preferred-skill coverage
+- Keyword coverage
+- Matched keywords
+- Missing keywords
+- Skill-category coverage
+- Detected seniority
+- Education requirement coverage
 
-**Modern Template**
-- Contemporary blue gradient header
-- Color-coded sections
-- Card-style education blocks
-- Eye-catching skill pills
+**Privacy/free guarantee:** Job Match runs locally in the browser using deterministic JavaScript. The job description and analysis are stored only in browser LocalStorage. Nothing is sent to an AI provider or paid service.
 
-**Minimal Template**
-- Ultra-clean design
-- Maximum whitespace
-- Light typography
-- Simple borders and lines
-- Perfect for ATS systems
+### 🧪 Automated Quality Checks
+Every pull request and push runs:
+- React unit tests
+- Production build
+- Playwright desktop browser tests
+- Playwright mobile browser tests
+- Dark-mode/responsive regression checks
+- Resume template switching checks
+- LocalStorage persistence checks
+- PDF download checks
+- Job Match analysis and persistence checks
+- GitHub Pages deployment only after all checks pass
 
 ## 🚀 Getting Started
 
 ### Prerequisites
 
-- Node.js (v14 or higher)
-- npm or yarn package manager
+- Node.js 18+ recommended
+- npm
 
 ### Installation
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/aniket-r2Dev2/work-exp-app.git
-   cd work-exp-app
-   ```
+```bash
+git clone https://github.com/aniket-r2Dev2/work-exp-app.git
+cd work-exp-app
+npm install
+npm start
+```
 
-2. **Install dependencies**
-   ```bash
-   npm install
-   ```
+Open `http://localhost:3000`.
 
-3. **Set up API keys (Optional but recommended)**
-   ```bash
-   # Create environment file
-   echo "REACT_APP_JSEARCH_API_KEY=your_api_key_here" > .env.local
-   ```
-   - Get your JSearch API key from [RapidAPI JSearch](https://rapidapi.com/letscrape-6bRBa3QguO5/api/jsearch)
-   - Replace `your_api_key_here` with your actual API key
-   - **Note:** The app works without the API key using local job titles only
-
-4. **Start the development server**
-   ```bash
-   npm start
-   ```
-
-5. **Open your browser**
-   - Navigate to [http://localhost:3000](http://localhost:3000) to view the application
-
-### Build for Production
+### Production build
 
 ```bash
 npm run build
 ```
-This creates an optimized production build in the `build` folder.
 
-## 🎯 How to Use
-
-### **Track Your Experience**
-
-1. **Add Your First Experience**
-   - Click "Add New Experience" button
-   - Fill in company details (autocomplete will suggest logos)
-   - Add position with smart autocomplete
-   - Add location with city autocomplete
-   - Select employment type (Full-time, Part-time, etc.)
-   - Add skills/technologies used
-   - Include job description and key achievements
-
-2. **Manage Your Timeline**
-   - View your total experience (years, months, days)
-   - Edit or remove existing experiences
-   - Mark current positions
-   - Track companies worked at
-
-### **Build Your Resume** ⭐
-
-1. **Add Profile Information**
-   - Click "Experiences" in navigation
-   - Navigate to "Resume" tab
-   - Click "Add Profile Info"
-   - Fill in your contact details and professional summary
-
-2. **Choose a Template**
-   - Select from Classic, Modern, or Minimal templates
-   - See live preview of your resume
-   - Switch templates anytime
-
-3. **Export Your Resume**
-   - **Download PDF** - High-quality PDF with custom filename
-   - **Print** - Optimized for professional printing
-   - Files named as: `Resume_YourName_2026-01-20.pdf`
-
-4. **What's Included**
-   - Professional summary
-   - Technical skills (aggregated from all roles)
-   - Work experience with achievements
-   - Skills used in each role
-   - Education (coming soon)
-   - Certifications (coming soon)
-
-## 📁 Project Structure
-
-```
-work-exp-app/
-├── public/
-│   ├── index.html
-│   └── favicon.ico
-├── src/
-│   ├── components/
-│   │   ├── cards/
-│   │   │   ├── ExperienceCard.js       # Experience display with skills
-│   │   │   └── SummaryCard.js          # Total experience summary
-│   │   ├── common/
-│   │   │   ├── Button.js               # Reusable button component
-│   │   │   └── Input.js                # Enhanced input with icons
-│   │   ├── forms/
-│   │   │   ├── ExperienceForm.js       # Experience form with skills
-│   │   │   └── ProfileForm.js          # Profile information form
-│   │   ├── layout/
-│   │   │   ├── EmptyState.js
-│   │   │   └── Header.js               # App header with navigation
-│   │   └── resume/
-│   │       ├── ResumePreview.js        # Original resume component
-│   │       └── templates/              # ⭐ NEW Resume templates
-│   │           ├── ClassicTemplate.js  # Traditional design
-│   │           ├── ModernTemplate.js   # Contemporary design
-│   │           └── MinimalTemplate.js  # Clean & simple design
-│   ├── config/
-│   │   ├── jobTitles.json              # 300+ job positions
-│   │   └── cities.json                 # 300+ major cities
-│   ├── hooks/
-│   │   ├── useExperience.js            # Experience state management
-│   │   ├── useProfile.js               # Profile state management
-│   │   └── useTheme.js                 # Dark mode management
-│   ├── pages/
-│   │   ├── Dashboard.js                # Main experiences page
-│   │   └── Resume.js                   # ⭐ Resume builder page
-│   ├── utils/
-│   │   └── dateUtils.js                # Date calculations
-│   ├── App.js                          # Main app with routing
-│   ├── index.css                       # ⭐ Global styles + print styles
-│   └── index.js                        # Entry point
-├── package.json                        # ⭐ Updated with PDF dependencies
-└── README.md
-```
-
-## 🔧 Technology Stack
-
-### Core
-- **React 19.1.0** - Latest React with modern hooks
-- **React Router** - Client-side routing
-- **Tailwind CSS** - Utility-first CSS framework
-- **Lucide React** - Beautiful icon library
-
-### Resume Builder ⭐
-- **react-to-print** - Print functionality
-- **html2canvas** - HTML to canvas conversion
-- **jsPDF** - PDF generation
-
-### APIs & Data
-- **Clearbit API** - Company logos and data
-- **JSearch API** - Job title autocomplete (optional)
-- **GeoDB Cities API** - Location autocomplete (optional)
-
-### Storage
-- **LocalStorage** - Client-side data persistence
-
-## 🎨 Resume Template Details
-
-### Classic Template
-- **Style:** Traditional, professional
-- **Font:** Georgia (serif)
-- **Colors:** Black, white, gray
-- **Best for:** Corporate, finance, legal, traditional industries
-- **Features:** Timeline, clear sections, conservative design
-
-### Modern Template  
-- **Style:** Contemporary, eye-catching
-- **Font:** System UI (sans-serif)
-- **Colors:** Blue gradients, color accents
-- **Best for:** Tech, startups, creative roles
-- **Features:** Colored header, skill badges, modern spacing
-
-### Minimal Template
-- **Style:** Clean, simple, scannable
-- **Font:** Helvetica Neue (sans-serif)
-- **Colors:** Grayscale only
-- **Best for:** ATS systems, tech roles, minimalists
-- **Features:** Maximum whitespace, light typography, text-based
-
-## 📊 Data Flow
-
-### Experience Data
-```javascript
-{
-  id: "timestamp",
-  company: "Company Name",
-  companyDomain: "company.com",
-  companyLogo: "https://logo.clearbit.com/company.com",
-  position: "Software Engineer",
-  location: "San Francisco, CA",
-  category: "Full-time",
-  startDate: "2021-06-01",
-  endDate: "2024-01-15",
-  current: false,
-  description: "Job description...",
-  skills: ["React", "Node.js", "AWS"],
-  achievements: [
-    "Led team of 5 developers",
-    "Increased performance by 40%"
-  ]
-}
-```
-
-### Profile Data
-```javascript
-{
-  fullName: "John Doe",
-  headline: "Senior Software Engineer",
-  email: "john@example.com",
-  phone: "+1 234 567 8900",
-  location: "San Francisco, CA",
-  linkedin: "linkedin.com/in/johndoe",
-  website: "johndoe.com",
-  summary: "Experienced software engineer..."
-}
-```
-
-## 🎯 Roadmap
-
-### Phase 1: Foundation ✅ (Complete)
-- [x] Experience tracking
-- [x] Skills management
-- [x] Data persistence
-- [x] Import/Export
-
-### Phase 2: Resume Builder ✅ (Complete)
-- [x] Multiple templates (3)
-- [x] PDF export
-- [x] Print support
-- [x] Template selector
-
-### Phase 3: Coming Soon 🚧
-- [ ] Education section
-- [ ] Certifications section
-- [ ] Custom template colors
-- [ ] More template options (Technical, Executive)
-- [ ] Resume scoring
-
-### Phase 4: AI Features 🎯
-- [ ] Job description analyzer
-- [ ] Resume vs JD matching
-- [ ] AI resume suggestions
-- [ ] Keyword optimization
-- [ ] ATS compatibility checker
-
-## 🔒 Privacy & Data
-
-- **Local Storage:** All data stored in browser localStorage
-- **No Server:** No data sent to external servers (except API calls)
-- **API Usage:**
-  - Clearbit: Company logos (no personal data)
-  - JSearch: Job titles (query only, optional)
-  - GeoDB: Cities (query only, optional)
-- **Export/Import:** Full control over your data
-
-## 🧪 Testing
-
-### Running Tests
+### Unit tests
 
 ```bash
 npm test
 ```
 
-### Test Coverage
+### Browser tests
 
 ```bash
-npm test -- --coverage
+npx playwright install chromium
+npm run build
+npm run test:e2e
 ```
 
-Tests are located in `src/__tests__/` directory.
+The browser suite starts the built application with the repository's GitHub Pages basename so routing is tested in the same shape as production.
+
+## 🎯 How to Use
+
+### Track your experience
+
+1. Open **Experiences**.
+2. Add your companies, roles, dates, skills and achievements.
+3. Your data is automatically persisted locally.
+4. Use JSON export for backups.
+
+### Build a resume
+
+1. Open **Resume**.
+2. Add your profile information.
+3. Add education, certifications and projects under **Resume Sections**.
+4. Choose Classic, Modern or Minimal.
+5. Download PDF or print.
+
+### Match a job description
+
+1. Open **Job Match**.
+2. Paste the complete job description.
+3. Select **Analyze Match**.
+4. Review the overall score, matched skills and gaps.
+5. Use the gaps as a checklist for improving your resume **only where they reflect real experience**.
+
+The current matcher is intentionally deterministic. It does not invent skills, achievements, metrics or experience.
+
+## 🧠 How Job Match Works
+
+The first version does not depend on a server or AI API.
+
+1. The JD is normalized locally.
+2. Known skills, seniority terms and education terms are detected.
+3. The engine searches the saved profile, experiences, education, certifications and projects.
+4. Required, preferred and overall keyword coverage are calculated.
+5. Results are grouped by skill category.
+
+The score is designed to be transparent rather than pretending to be an authoritative ATS score. It is a useful comparison signal, not a hiring prediction.
+
+### Scoring
+
+- Required skills: 60%
+- Overall detected keyword coverage: 25%
+- Preferred skills: 10%
+- Education requirement: 5%
+
+When a JD contains no recognized keywords, the analyzer does not penalize the user for something it cannot understand.
+
+## 🔒 Privacy & Free-Use Principles
+
+- Career data is stored in browser LocalStorage.
+- Job descriptions and Job Match results are stored locally.
+- Job Match has no backend and no external AI calls.
+- No paid package is required for Job Match.
+- No API key is required for Job Match.
+- Export/import lets users keep control of their data.
+
+Some older autocomplete functionality in the application may use optional external data integrations. The Job Match feature intentionally does **not** add any paid dependency or external service.
+
+## 🧱 Technology Stack
+
+### Core
+- React 19
+- React Router
+- Tailwind CSS
+- Lucide React
+
+### Resume
+- react-to-print
+- html2canvas
+- jsPDF
+
+### Testing
+- React Testing Library
+- Jest via Create React App
+- Playwright
+
+### Storage
+- Browser LocalStorage
+
+### Deployment
+- GitHub Actions
+- GitHub Pages
+
+No new paid service, hosted database, AI API, or proprietary SDK is required by the Job Match feature.
+
+## 📁 Project Structure
+
+```text
+work-exp-app/
+├── e2e/
+│   ├── server.js
+│   ├── resume-builder.spec.js
+│   └── job-match.spec.js
+├── src/
+│   ├── components/
+│   │   ├── common/
+│   │   ├── forms/
+│   │   ├── layout/
+│   │   └── resume/
+│   ├── config/
+│   ├── hooks/
+│   │   ├── useExperience.js
+│   │   ├── useProfile.js
+│   │   ├── useResumeSections.js
+│   │   └── useJobMatch.js
+│   ├── pages/
+│   │   ├── Dashboard.js
+│   │   ├── Resume.js
+│   │   └── JobMatch.js
+│   ├── utils/
+│   │   ├── dateUtils.js
+│   │   └── jobMatchUtils.js
+│   └── __tests__/
+├── playwright.config.js
+└── .github/workflows/deploy.yml
+```
+
+## 🗺️ Roadmap
+
+### Phase 1 — Foundation ✅
+- [x] Experience tracking
+- [x] Skills management
+- [x] Local persistence
+- [x] Import/export
+- [x] Responsive UI
+- [x] Dark mode
+
+### Phase 2 — Resume Builder ✅
+- [x] Profile
+- [x] Work experience
+- [x] Education
+- [x] Certifications
+- [x] Projects
+- [x] Three templates
+- [x] PDF export
+- [x] Print support
+
+### Phase 3 — Job Intelligence 🚧
+- [x] Local JD analyzer
+- [x] Resume/profile vs JD matching
+- [x] Required/preferred skill detection
+- [x] Match score
+- [x] Keyword gap analysis
+- [x] Skill-category coverage
+- [ ] Canonical profile skill library
+- [ ] Resume versions per target job
+- [ ] Job application tracker
+
+### Phase 4 — Optional AI, still privacy-conscious 🎯
+- [ ] AI-assisted rewriting with an explicitly optional provider
+- [ ] Tailored resume suggestions
+- [ ] Before/after comparison
+- [ ] User approval for every generated change
+- [ ] Never invent experience, metrics or skills
+
+Any future AI integration should remain optional. The core product must continue to work fully without a paid AI service.
 
 ## 🚀 Deployment
 
-### GitHub Pages
+The production site is deployed through GitHub Pages after the CI pipeline passes.
 
-```bash
-npm run deploy
-```
+Live app:
 
-Your app will be live at: `https://aniket-r2dev2.github.io/work-exp-app/`
+https://aniket-r2dev2.github.io/work-exp-app/
 
-### CI/CD
+GitHub Actions workflow:
 
-GitHub Actions automatically:
-1. Runs tests on every push
-2. Builds the project
-3. Deploys to GitHub Pages
+`.github/workflows/deploy.yml`
 
-Workflow: `.github/workflows/deploy.yml`
+The deployment job is deliberately last in the pipeline, so a failing unit test, build, or browser regression blocks deployment.
 
-## 📝 Contributing
+## 🤝 Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. Create a feature branch.
+2. Implement the feature with unit tests.
+3. Add Playwright coverage for user-visible workflows where appropriate.
+4. Run the production build.
+5. Open a pull request.
+6. Merge only after CI is green.
 
 ## 📄 License
 
-MIT License - see LICENSE file for details
-
-## 🤝 Acknowledgments
-
-- Clearbit for company data and logos
-- JSearch API for job titles
-- GeoDB Cities for location data
-- Lucide for beautiful icons
-- Tailwind CSS for styling framework
-- React team for the amazing framework
-- Open source community
-
-## 📧 Contact
-
-- **Developer:** Aniket Anil Kumar
-- **GitHub:** [@aniket-r2Dev2](https://github.com/aniket-r2Dev2)
-- **Project:** [work-exp-app](https://github.com/aniket-r2Dev2/work-exp-app)
-- **Live Demo:** [https://aniket-r2dev2.github.io/work-exp-app/](https://aniket-r2dev2.github.io/work-exp-app/)
+MIT License — see `LICENSE`.
 
 ---
 
-**Built with ❤️ using React and modern web technologies**
-
-⭐ Star this repo if you find it helpful!
+Built with React and open-source tooling. ❤️

--- a/e2e/job-match.spec.js
+++ b/e2e/job-match.spec.js
@@ -23,9 +23,9 @@ test.describe('Job Match browser regression', () => {
     await page.getByLabel('Job description').fill(jobDescription);
     await page.getByRole('button', { name: 'Analyze Match' }).click();
     await expect(page.getByText(/Strong match|Good match|Partial match|Low match/)).toBeVisible();
-    await expect(page.getByText('java', { exact: true })).toBeVisible();
-    await expect(page.getByText('kubernetes', { exact: true })).toBeVisible();
-    await expect(page.getByText('terraform', { exact: true })).toBeVisible();
+    await expect(page.getByText('java', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('kubernetes', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('terraform', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Skill coverage')).toBeVisible();
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBeTruthy();
     await page.screenshot({ path: testInfo.outputPath('job-match-desktop.png'), fullPage: true });

--- a/e2e/job-match.spec.js
+++ b/e2e/job-match.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require('@playwright/test');
+
+const jobDescription = `Senior Backend Engineer\nRequired: Java, Spring Boot, AWS, Kubernetes\nNice to have: Kafka, Terraform\nBachelor's degree preferred`;
+
+const seedProfile = async (page) => {
+  await page.evaluate(() => {
+    localStorage.setItem('user_profile_data', JSON.stringify({ fullName: 'Alex Engineer', headline: 'Senior Backend Engineer', email: 'alex@example.com', phone: '', location: 'Bengaluru', linkedin: '', website: '', summary: 'Senior engineer building Java services on AWS.' }));
+    localStorage.setItem('work_experience_data', JSON.stringify({ version: '1.0', experiences: [{ id: 1, company: 'Acme', position: 'Software Engineer', location: 'Bengaluru', startDate: '2021-01-01', endDate: '', current: true, description: 'Built Spring Boot microservices with Kubernetes.', skills: ['Java', 'AWS', 'Spring Boot'], achievements: [] }] }));
+    localStorage.setItem('resume_sections_data', JSON.stringify({ education: [{ id: 1, degree: 'Bachelor of Technology', institution: 'Example University', location: 'Bengaluru', startYear: '2017', endYear: '2021', gpa: '8.8' }], certifications: [], projects: [{ id: 1, name: 'Event Platform', description: 'Kafka based services', technologies: 'Java, Kafka', url: '', github: '', startDate: '', endDate: '' }] }));
+  });
+};
+
+test.describe('Job Match browser regression', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('./job-match', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: 'Job Match' })).toBeVisible();
+    await seedProfile(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: 'Job Match' })).toBeVisible();
+  });
+
+  test('analyzes a JD and shows matched skills and gaps', async ({ page }, testInfo) => {
+    await page.getByLabel('Job description').fill(jobDescription);
+    await page.getByRole('button', { name: 'Analyze Match' }).click();
+    await expect(page.getByText(/Strong match|Good match|Partial match|Low match/)).toBeVisible();
+    await expect(page.getByText('java', { exact: true })).toBeVisible();
+    await expect(page.getByText('kubernetes', { exact: true })).toBeVisible();
+    await expect(page.getByText('terraform', { exact: true })).toBeVisible();
+    await expect(page.getByText('Skill coverage')).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBeTruthy();
+    await page.screenshot({ path: testInfo.outputPath('job-match-desktop.png'), fullPage: true });
+  });
+
+  test('persists the JD and analysis after refresh', async ({ page }) => {
+    await page.getByLabel('Job description').fill(jobDescription);
+    await page.getByRole('button', { name: 'Analyze Match' }).click();
+    await expect(page.getByText('Skill coverage')).toBeVisible();
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.getByLabel('Job description')).toHaveValue(jobDescription);
+    await expect(page.getByText('Skill coverage')).toBeVisible();
+  });
+
+  test('mobile layout keeps the matcher usable', async ({ page }, testInfo) => {
+    await expect(page.getByLabel('Job description')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Analyze Match' })).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBeTruthy();
+    await page.screenshot({ path: testInfo.outputPath('job-match-mobile.png'), fullPage: true });
+  });
+});

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -68,6 +68,8 @@ function assertNoHorizontalOverflow(page) {
   return page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1);
 }
 
+const preview = (page) => page.getByTestId('resume-preview');
+
 async function assertContactAlignment(page) {
   const items = preview(page).getByTestId('resume-contact-item');
   const count = await items.count();
@@ -85,8 +87,6 @@ async function assertContactAlignment(page) {
     expect(Math.abs(iconCenter - textCenter)).toBeLessThanOrEqual(2);
   }
 }
-
-const preview = (page) => page.getByTestId('resume-preview');
 
 async function expectPreviewProject(page) {
   await expect(preview(page).getByRole('heading', { name: 'Developer Platform' })).toBeVisible();

--- a/e2e/resume-builder.spec.js
+++ b/e2e/resume-builder.spec.js
@@ -68,6 +68,24 @@ function assertNoHorizontalOverflow(page) {
   return page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1);
 }
 
+async function assertContactAlignment(page) {
+  const items = preview(page).getByTestId('resume-contact-item');
+  const count = await items.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i += 1) {
+    const item = items.nth(i);
+    const icon = item.locator('svg');
+    const text = item.locator('span').last();
+    const [iconBox, textBox] = await Promise.all([icon.boundingBox(), text.boundingBox()]);
+    expect(iconBox).not.toBeNull();
+    expect(textBox).not.toBeNull();
+    const iconCenter = iconBox.y + (iconBox.height / 2);
+    const textCenter = textBox.y + (textBox.height / 2);
+    expect(Math.abs(iconCenter - textCenter)).toBeLessThanOrEqual(2);
+  }
+}
+
 const preview = (page) => page.getByTestId('resume-preview');
 
 async function expectPreviewProject(page) {
@@ -92,6 +110,7 @@ test.describe('Resume Builder browser regression', () => {
       await page.getByRole('button', { name: new RegExp(`^${template}`) }).click();
       await expect(preview(page).getByText('Alex Engineer')).toBeVisible();
       await expectPreviewProject(page);
+      await assertContactAlignment(page);
       await expect(preview(page)).toBeVisible();
     }
 
@@ -101,6 +120,7 @@ test.describe('Resume Builder browser regression', () => {
     await expect(page.getByText('B.Tech in Computer Science')).toBeVisible();
     await expect(page.getByText('AWS Certified Developer')).toBeVisible();
     await expectPreviewProject(page);
+    await assertContactAlignment(page);
 
     const downloadPromise = page.waitForEvent('download');
     await page.getByRole('button', { name: /download pdf/i }).click();

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import Navigation from './components/layout/Navigation';
 import Dashboard from './pages/Dashboard';
 import Resume from './pages/Resume';
+import JobMatch from './pages/JobMatch';
 
 const App = () => {
   return (
@@ -12,6 +13,7 @@ const App = () => {
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/resume" element={<Resume />} />
+          <Route path="/job-match" element={<JobMatch />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </div>

--- a/src/__tests__/jobMatchUtils.test.js
+++ b/src/__tests__/jobMatchUtils.test.js
@@ -1,0 +1,45 @@
+import { analyzeJobDescription, extractKeywords, extractRequirements, getMatchLabel } from '../utils/jobMatchUtils';
+
+describe('jobMatchUtils', () => {
+  const job = `Senior Backend Engineer\nRequired: Java, Spring Boot, AWS, Kubernetes\nNice to have: Kafka, Terraform\nBachelor's degree preferred`;
+  const profile = {
+    profile: { headline: 'Senior Backend Engineer', summary: 'Backend engineer building Java services on AWS.' },
+    experiences: [{ position: 'Software Engineer', company: 'Acme', description: 'Built Spring Boot microservices with Kubernetes.', skills: ['Java', 'AWS', 'Spring Boot'], achievements: [] }],
+    education: [{ degree: 'Bachelor of Technology', institution: 'University' }],
+    certifications: [],
+    projects: [{ name: 'Event platform', description: 'Kafka based services', technologies: 'Java, Kafka' }]
+  };
+
+  test('extracts known keywords case-insensitively', () => {
+    expect(extractKeywords(job)).toEqual(expect.arrayContaining(['java', 'spring boot', 'aws', 'kubernetes', 'kafka', 'terraform', 'senior', 'bachelor']));
+  });
+
+  test('classifies required and preferred skills', () => {
+    const result = extractRequirements(job);
+    expect(result.required).toEqual(expect.arrayContaining(['java', 'spring boot', 'aws', 'kubernetes']));
+    expect(result.preferred).toEqual(expect.arrayContaining(['kafka', 'terraform']));
+  });
+
+  test('matches skills across profile, experience, education and projects', () => {
+    const result = analyzeJobDescription(job, profile);
+    expect(result.matched).toEqual(expect.arrayContaining(['java', 'spring boot', 'aws', 'kubernetes', 'kafka']));
+    expect(result.missing).toContain('terraform');
+    expect(result.requiredScore).toBe(100);
+    expect(result.score).toBeGreaterThan(70);
+    expect(result.categories.find((category) => category.name === 'Cloud').score).toBe(100);
+  });
+
+  test('handles a job with no recognized keywords', () => {
+    const result = analyzeJobDescription('Join our amazing team and make an impact.', profile);
+    expect(result.score).toBe(100);
+    expect(result.keywords).toEqual([]);
+    expect(result.categories).toEqual([]);
+  });
+
+  test('returns stable labels for score bands', () => {
+    expect(getMatchLabel(90)).toBe('Strong match');
+    expect(getMatchLabel(75)).toBe('Good match');
+    expect(getMatchLabel(55)).toBe('Partial match');
+    expect(getMatchLabel(20)).toBe('Low match');
+  });
+});

--- a/src/components/layout/Navigation.js
+++ b/src/components/layout/Navigation.js
@@ -1,52 +1,22 @@
 import React from 'react';
+import { Briefcase, FileSearch, FileText } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
-import { Briefcase, FileText } from 'lucide-react';
 
 const Navigation = () => {
   const location = useLocation();
-  
-  const isActive = (path) => {
-    return location.pathname === path;
-  };
+  const isActive = (path) => location.pathname === path;
+  const linkClass = (path) => `flex items-center space-x-2 px-3 sm:px-4 py-2 rounded-lg font-medium transition-all duration-200 ${isActive(path) ? 'bg-linkedin-50 dark:bg-linkedin-900 text-linkedin-700 dark:text-linkedin-200' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700'}`;
 
   return (
     <nav className="bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-50 shadow-sm">
-      <div className="container mx-auto px-4">
-        <div className="flex items-center justify-between h-16">
-          {/* Logo/Brand */}
-          <Link to="/" className="flex items-center space-x-2 text-linkedin-600 hover:text-linkedin-700 transition-colors">
-            <Briefcase className="w-6 h-6" />
-            <span className="font-bold text-lg hidden sm:inline">Work Experience Tracker</span>
-            <span className="font-bold text-lg sm:hidden">WE Tracker</span>
-          </Link>
-
-          {/* Navigation Links */}
-          <div className="flex space-x-1">
-            <Link
-              to="/"
-              className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
-                isActive('/')
-                  ? 'bg-linkedin-50 dark:bg-linkedin-900 text-linkedin-700 dark:text-linkedin-200'
-                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700'
-              }`}
-            >
-              <Briefcase className="w-4 h-4" />
-              <span className="hidden sm:inline">Experiences</span>
-            </Link>
-            <Link
-              to="/resume"
-              className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
-                isActive('/resume')
-                  ? 'bg-linkedin-50 dark:bg-linkedin-900 text-linkedin-700 dark:text-linkedin-200'
-                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700'
-              }`}
-            >
-              <FileText className="w-4 h-4" />
-              <span className="hidden sm:inline">Resume</span>
-            </Link>
-          </div>
+      <div className="container mx-auto px-4"><div className="flex items-center justify-between h-16 gap-2">
+        <Link to="/" className="flex items-center space-x-2 text-linkedin-600 hover:text-linkedin-700 transition-colors shrink-0"><Briefcase className="w-6 h-6" /><span className="font-bold text-lg hidden sm:inline">Work Experience Tracker</span><span className="font-bold text-lg sm:hidden">WE Tracker</span></Link>
+        <div className="flex space-x-1 overflow-x-auto">
+          <Link to="/" className={linkClass('/')}><Briefcase className="w-4 h-4" /><span className="hidden sm:inline">Experiences</span></Link>
+          <Link to="/resume" className={linkClass('/resume')}><FileText className="w-4 h-4" /><span className="hidden sm:inline">Resume</span></Link>
+          <Link to="/job-match" className={linkClass('/job-match')}><FileSearch className="w-4 h-4" /><span className="hidden sm:inline">Job Match</span></Link>
         </div>
-      </div>
+      </div></div>
     </nav>
   );
 };

--- a/src/components/resume/templates/ClassicTemplate.js
+++ b/src/components/resume/templates/ClassicTemplate.js
@@ -2,6 +2,15 @@ import React from 'react';
 import { Mail, Phone, MapPin, Linkedin, Globe, Calendar, Building2, Code2, Award, GraduationCap } from 'lucide-react';
 import { formatDate, calculateDuration } from '../../../utils/dateUtils';
 
+const contactItem = (Icon, content, key) => (
+  <div key={key} data-testid="resume-contact-item" className="inline-flex items-center text-sm text-gray-600 leading-5">
+    <span className="inline-flex items-center justify-center w-4 h-5 shrink-0 mr-1">
+      <Icon className="w-4 h-4 block" />
+    </span>
+    <span className="leading-5">{content}</span>
+  </div>
+);
+
 const ClassicTemplate = React.forwardRef(({ profile, experiences, education = [], certifications = [] }, ref) => {
   // Sort experiences by start date (most recent first)
   const sortedExperiences = [...experiences].sort((a, b) => {
@@ -31,36 +40,11 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
         )}
         
         <div className="flex flex-wrap gap-4 text-sm text-gray-600">
-          {profile.email && (
-            <div className="flex items-center">
-              <Mail className="w-4 h-4 mr-1" />
-              {profile.email}
-            </div>
-          )}
-          {profile.phone && (
-            <div className="flex items-center">
-              <Phone className="w-4 h-4 mr-1" />
-              {profile.phone}
-            </div>
-          )}
-          {profile.location && (
-            <div className="flex items-center">
-              <MapPin className="w-4 h-4 mr-1" />
-              {profile.location}
-            </div>
-          )}
-          {profile.linkedin && (
-            <div className="flex items-center">
-              <Linkedin className="w-4 h-4 mr-1" />
-              <span>LinkedIn</span>
-            </div>
-          )}
-          {profile.website && (
-            <div className="flex items-center">
-              <Globe className="w-4 h-4 mr-1" />
-              <span>Portfolio</span>
-            </div>
-          )}
+          {profile.email && contactItem(Mail, profile.email, 'email')}
+          {profile.phone && contactItem(Phone, profile.phone, 'phone')}
+          {profile.location && contactItem(MapPin, profile.location, 'location')}
+          {profile.linkedin && contactItem(Linkedin, 'LinkedIn', 'linkedin')}
+          {profile.website && contactItem(Globe, 'Portfolio', 'website')}
         </div>
       </div>
 
@@ -79,16 +63,12 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {/* Technical Skills */}
       {allSkills.length > 0 && (
         <div className="mb-8">
-          <h3 className="text-xl font-bold text-gray-900 mb-3 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center">
-            <Code2 className="w-5 h-5 mr-2" />
+          <h3 className="text-xl font-bold text-gray-900 mb-3 uppercase tracking-wide border-b border-gray-300 pb-2">
             Technical Skills
           </h3>
           <div className="flex flex-wrap gap-2">
             {allSkills.map((skill, index) => (
-              <span
-                key={index}
-                className="inline-block px-3 py-1 bg-gray-100 text-gray-800 rounded text-sm font-medium"
-              >
+              <span key={index} className="px-3 py-1 bg-gray-100 text-gray-700 rounded text-sm">
                 {skill}
               </span>
             ))}
@@ -100,50 +80,38 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {sortedExperiences.length > 0 && (
         <div className="mb-8">
           <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2">
-            Work Experience
+            Professional Experience
           </h3>
           <div className="space-y-6">
             {sortedExperiences.map((exp, index) => (
-              <div key={exp.id || index} className="relative pl-8 border-l-2 border-gray-300">
-                <div className="absolute left-0 top-0 w-3 h-3 bg-gray-800 rounded-full" style={{ marginLeft: '-7px' }}></div>
-                
-                <div className="mb-2">
-                  <h4 className="text-lg font-bold text-gray-900">{exp.position}</h4>
-                  <div className="flex items-center text-gray-700 font-semibold">
-                    <Building2 className="w-4 h-4 mr-1" />
-                    {exp.company}
-                    {exp.location && (
-                      <span className="mx-2 text-gray-400">•</span>
-                    )}
-                    {exp.location && (
-                      <span className="flex items-center">
-                        <MapPin className="w-4 h-4 mr-1" />
-                        {exp.location}
-                      </span>
-                    )}
+              <div key={exp.id || index} className="border-l-2 border-gray-300 pl-4">
+                <div className="flex justify-between items-start mb-2">
+                  <div>
+                    <h4 className="text-lg font-bold text-gray-900">{exp.position}</h4>
+                    <p className="text-gray-700 font-semibold">{exp.company}</p>
+                    {exp.location && <p className="text-sm text-gray-600">{exp.location}</p>}
                   </div>
-                  <div className="flex items-center text-sm text-gray-600 mt-1">
-                    <Calendar className="w-4 h-4 mr-1" />
-                    {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
-                    <span className="mx-2">•</span>
-                    {calculateDuration(exp.startDate, exp.endDate, exp.current)}
+                  <div className="text-right text-sm text-gray-600">
+                    <div className="flex items-center justify-end">
+                      <Calendar className="w-4 h-4 mr-1" />
+                      {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
+                    </div>
+                    <div className="mt-1 font-medium">
+                      {calculateDuration(exp.startDate, exp.endDate, exp.current)}
+                    </div>
                   </div>
                 </div>
 
                 {exp.description && (
-                  <p className="text-gray-700 mb-3 leading-relaxed">
+                  <p className="text-gray-700 mb-2 leading-relaxed">
                     {exp.description}
                   </p>
                 )}
 
-                {/* Skills for this experience */}
                 {exp.skills && exp.skills.length > 0 && (
-                  <div className="mb-3">
-                    <p className="text-sm text-gray-600 font-semibold mb-1">Technologies:</p>
-                    <p className="text-sm text-gray-700">
-                      {exp.skills.join(' • ')}
-                    </p>
-                  </div>
+                  <p className="text-sm text-gray-600 mb-2">
+                    <strong>Technologies:</strong> {exp.skills.join(', ')}
+                  </p>
                 )}
 
                 {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && (
@@ -162,8 +130,7 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {/* Education */}
       {education.length > 0 && (
         <div className="mb-8">
-          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center">
-            <GraduationCap className="w-5 h-5 mr-2" />
+          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2">
             Education
           </h3>
           <div className="space-y-4">
@@ -172,8 +139,8 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
                 <h4 className="text-lg font-bold text-gray-900">{edu.degree}</h4>
                 <p className="text-gray-700 font-semibold">{edu.institution}</p>
                 <p className="text-sm text-gray-600">
-                  {edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
-                  {edu.gpa && <span> • GPA: {edu.gpa}</span>}
+                  {edu.location && `${edu.location} • `}{edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
+                  {edu.gpa && ` • GPA: ${edu.gpa}`}
                 </p>
               </div>
             ))}
@@ -184,18 +151,18 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {/* Certifications */}
       {certifications.length > 0 && (
         <div className="mb-8">
-          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center">
-            <Award className="w-5 h-5 mr-2" />
+          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2">
             Certifications
           </h3>
-          <div className="space-y-2">
+          <div className="space-y-3">
             {certifications.map((cert, index) => (
               <div key={index}>
                 <h4 className="font-bold text-gray-900">{cert.name}</h4>
                 <p className="text-sm text-gray-700">
                   {cert.issuer}
-                  {cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}
-                  {cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}
+                  {cert.issueDate && ` • ${formatDate(cert.issueDate)}`}
+                  {cert.expiryDate && ` • Expires: ${formatDate(cert.expiryDate)}`}
+                  {cert.credentialId && ` • ID: ${cert.credentialId}`}
                 </p>
               </div>
             ))}
@@ -203,7 +170,7 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
         </div>
       )}
 
-      {/* Footer Note */}
+      {/* Footer */}
       {sortedExperiences.length === 0 && !profile.summary && (
         <div className="text-center text-gray-400 py-12">
           <p>Add your profile information and work experiences to generate your resume.</p>

--- a/src/components/resume/templates/ClassicTemplate.js
+++ b/src/components/resume/templates/ClassicTemplate.js
@@ -63,12 +63,16 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {/* Technical Skills */}
       {allSkills.length > 0 && (
         <div className="mb-8">
-          <h3 className="text-xl font-bold text-gray-900 mb-3 uppercase tracking-wide border-b border-gray-300 pb-2">
+          <h3 className="text-xl font-bold text-gray-900 mb-3 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center">
+            <Code2 className="w-5 h-5 mr-2" />
             Technical Skills
           </h3>
           <div className="flex flex-wrap gap-2">
             {allSkills.map((skill, index) => (
-              <span key={index} className="px-3 py-1 bg-gray-100 text-gray-700 rounded text-sm">
+              <span
+                key={index}
+                className="inline-block px-3 py-1 bg-gray-100 text-gray-800 rounded text-sm font-medium"
+              >
                 {skill}
               </span>
             ))}
@@ -80,38 +84,50 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {sortedExperiences.length > 0 && (
         <div className="mb-8">
           <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2">
-            Professional Experience
+            Work Experience
           </h3>
           <div className="space-y-6">
             {sortedExperiences.map((exp, index) => (
-              <div key={exp.id || index} className="border-l-2 border-gray-300 pl-4">
-                <div className="flex justify-between items-start mb-2">
-                  <div>
-                    <h4 className="text-lg font-bold text-gray-900">{exp.position}</h4>
-                    <p className="text-gray-700 font-semibold">{exp.company}</p>
-                    {exp.location && <p className="text-sm text-gray-600">{exp.location}</p>}
+              <div key={exp.id || index} className="relative pl-8 border-l-2 border-gray-300">
+                <div className="absolute left-0 top-0 w-3 h-3 bg-gray-800 rounded-full" style={{ marginLeft: '-7px' }}></div>
+                
+                <div className="mb-2">
+                  <h4 className="text-lg font-bold text-gray-900">{exp.position}</h4>
+                  <div className="flex items-center text-gray-700 font-semibold">
+                    <Building2 className="w-4 h-4 mr-1" />
+                    {exp.company}
+                    {exp.location && (
+                      <span className="mx-2 text-gray-400">•</span>
+                    )}
+                    {exp.location && (
+                      <span className="flex items-center">
+                        <MapPin className="w-4 h-4 mr-1" />
+                        {exp.location}
+                      </span>
+                    )}
                   </div>
-                  <div className="text-right text-sm text-gray-600">
-                    <div className="flex items-center justify-end">
-                      <Calendar className="w-4 h-4 mr-1" />
-                      {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
-                    </div>
-                    <div className="mt-1 font-medium">
-                      {calculateDuration(exp.startDate, exp.endDate, exp.current)}
-                    </div>
+                  <div className="flex items-center text-sm text-gray-600 mt-1">
+                    <Calendar className="w-4 h-4 mr-1" />
+                    {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
+                    <span className="mx-2">•</span>
+                    {calculateDuration(exp.startDate, exp.endDate, exp.current)}
                   </div>
                 </div>
 
                 {exp.description && (
-                  <p className="text-gray-700 mb-2 leading-relaxed">
+                  <p className="text-gray-700 mb-3 leading-relaxed">
                     {exp.description}
                   </p>
                 )}
 
+                {/* Skills for this experience */}
                 {exp.skills && exp.skills.length > 0 && (
-                  <p className="text-sm text-gray-600 mb-2">
-                    <strong>Technologies:</strong> {exp.skills.join(', ')}
-                  </p>
+                  <div className="mb-3">
+                    <p className="text-sm text-gray-600 font-semibold mb-1">Technologies:</p>
+                    <p className="text-sm text-gray-700">
+                      {exp.skills.join(' • ')}
+                    </p>
+                  </div>
                 )}
 
                 {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && (
@@ -130,7 +146,8 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {/* Education */}
       {education.length > 0 && (
         <div className="mb-8">
-          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2">
+          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center">
+            <GraduationCap className="w-5 h-5 mr-2" />
             Education
           </h3>
           <div className="space-y-4">
@@ -139,8 +156,8 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
                 <h4 className="text-lg font-bold text-gray-900">{edu.degree}</h4>
                 <p className="text-gray-700 font-semibold">{edu.institution}</p>
                 <p className="text-sm text-gray-600">
-                  {edu.location && `${edu.location} • `}{edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
-                  {edu.gpa && ` • GPA: ${edu.gpa}`}
+                  {edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
+                  {edu.gpa && <span> • GPA: {edu.gpa}</span>}
                 </p>
               </div>
             ))}
@@ -151,18 +168,18 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
       {/* Certifications */}
       {certifications.length > 0 && (
         <div className="mb-8">
-          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2">
+          <h3 className="text-xl font-bold text-gray-900 mb-4 uppercase tracking-wide border-b border-gray-300 pb-2 flex items-center">
+            <Award className="w-5 h-5 mr-2" />
             Certifications
           </h3>
-          <div className="space-y-3">
+          <div className="space-y-2">
             {certifications.map((cert, index) => (
               <div key={index}>
                 <h4 className="font-bold text-gray-900">{cert.name}</h4>
                 <p className="text-sm text-gray-700">
                   {cert.issuer}
-                  {cert.issueDate && ` • ${formatDate(cert.issueDate)}`}
-                  {cert.expiryDate && ` • Expires: ${formatDate(cert.expiryDate)}`}
-                  {cert.credentialId && ` • ID: ${cert.credentialId}`}
+                  {cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}
+                  {cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}
                 </p>
               </div>
             ))}
@@ -170,7 +187,7 @@ const ClassicTemplate = React.forwardRef(({ profile, experiences, education = []
         </div>
       )}
 
-      {/* Footer */}
+      {/* Footer Note */}
       {sortedExperiences.length === 0 && !profile.summary && (
         <div className="text-center text-gray-400 py-12">
           <p>Add your profile information and work experiences to generate your resume.</p>

--- a/src/components/resume/templates/MinimalTemplate.js
+++ b/src/components/resume/templates/MinimalTemplate.js
@@ -3,6 +3,15 @@ import { Mail, Phone, MapPin, Linkedin, Globe } from 'lucide-react';
 import { formatDate, calculateDuration } from '../../../utils/dateUtils';
 import ResumeAdditionalSections from '../ResumeAdditionalSections';
 
+const contactItem = (Icon, content, key) => (
+  <div key={key} data-testid="resume-contact-item" className="inline-flex items-center text-sm text-gray-600 font-light leading-5">
+    <span className="inline-flex items-center justify-center w-3.5 h-5 shrink-0 mr-1.5">
+      <Icon className="w-3.5 h-3.5 block" />
+    </span>
+    <span className="leading-5">{content}</span>
+  </div>
+);
+
 const MinimalTemplate = React.forwardRef(({ profile, experiences, education = [], certifications = [], projects = [] }, ref) => {
   const sortedExperiences = [...experiences].sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
   const allSkills = [...new Set(sortedExperiences.filter(exp => exp.skills?.length).flatMap(exp => exp.skills))];
@@ -13,11 +22,11 @@ const MinimalTemplate = React.forwardRef(({ profile, experiences, education = []
         <h1 className="text-5xl font-light text-gray-900 mb-1 tracking-tight">{profile.fullName || 'Your Name'}</h1>
         {profile.headline && <p className="text-lg text-gray-600 font-light mb-4">{profile.headline}</p>}
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600 font-light border-t border-b border-gray-200 py-3 mt-4">
-          {profile.email && <div className="flex items-center"><Mail className="w-3.5 h-3.5 mr-1.5" />{profile.email}</div>}
-          {profile.phone && <div className="flex items-center"><Phone className="w-3.5 h-3.5 mr-1.5" />{profile.phone}</div>}
-          {profile.location && <div className="flex items-center"><MapPin className="w-3.5 h-3.5 mr-1.5" />{profile.location}</div>}
-          {profile.linkedin && <div className="flex items-center"><Linkedin className="w-3.5 h-3.5 mr-1.5" />LinkedIn</div>}
-          {profile.website && <div className="flex items-center"><Globe className="w-3.5 h-3.5 mr-1.5" />Portfolio</div>}
+          {profile.email && contactItem(Mail, profile.email, 'email')}
+          {profile.phone && contactItem(Phone, profile.phone, 'phone')}
+          {profile.location && contactItem(MapPin, profile.location, 'location')}
+          {profile.linkedin && contactItem(Linkedin, 'LinkedIn', 'linkedin')}
+          {profile.website && contactItem(Globe, 'Portfolio', 'website')}
         </div>
       </div>
 

--- a/src/components/resume/templates/ModernTemplate.js
+++ b/src/components/resume/templates/ModernTemplate.js
@@ -2,6 +2,15 @@ import React from 'react';
 import { Mail, Phone, MapPin, Linkedin, Globe, Calendar, Building2, Code2, Award, GraduationCap } from 'lucide-react';
 import { formatDate, calculateDuration } from '../../../utils/dateUtils';
 
+const contactItem = (Icon, content, key) => (
+  <div key={key} data-testid="resume-contact-item" className="inline-flex items-center text-sm text-blue-100 leading-5">
+    <span className="inline-flex items-center justify-center w-4 h-5 shrink-0 mr-1">
+      <Icon className="w-4 h-4 block" />
+    </span>
+    <span className="leading-5">{content}</span>
+  </div>
+);
+
 const ModernTemplate = React.forwardRef(({ profile, experiences, education = [], certifications = [] }, ref) => {
   const sortedExperiences = [...experiences].sort((a, b) => {
     const dateA = new Date(a.startDate);
@@ -29,36 +38,11 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
         )}
         
         <div className="flex flex-wrap gap-4 text-sm text-blue-100">
-          {profile.email && (
-            <div className="flex items-center">
-              <Mail className="w-4 h-4 mr-1" />
-              {profile.email}
-            </div>
-          )}
-          {profile.phone && (
-            <div className="flex items-center">
-              <Phone className="w-4 h-4 mr-1" />
-              {profile.phone}
-            </div>
-          )}
-          {profile.location && (
-            <div className="flex items-center">
-              <MapPin className="w-4 h-4 mr-1" />
-              {profile.location}
-            </div>
-          )}
-          {profile.linkedin && (
-            <div className="flex items-center">
-              <Linkedin className="w-4 h-4 mr-1" />
-              <span>LinkedIn</span>
-            </div>
-          )}
-          {profile.website && (
-            <div className="flex items-center">
-              <Globe className="w-4 h-4 mr-1" />
-              <span>Portfolio</span>
-            </div>
-          )}
+          {profile.email && contactItem(Mail, profile.email, 'email')}
+          {profile.phone && contactItem(Phone, profile.phone, 'phone')}
+          {profile.location && contactItem(MapPin, profile.location, 'location')}
+          {profile.linkedin && contactItem(Linkedin, 'LinkedIn', 'linkedin')}
+          {profile.website && contactItem(Globe, 'Portfolio', 'website')}
         </div>
       </div>
 
@@ -84,12 +68,7 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
             </h3>
             <div className="flex flex-wrap gap-2 pl-6">
               {allSkills.map((skill, index) => (
-                <span
-                  key={index}
-                  className="px-4 py-2 bg-blue-50 text-blue-700 rounded-full text-sm font-semibold border border-blue-200"
-                >
-                  {skill}
-                </span>
+                <span key={index} className="px-4 py-2 bg-blue-50 text-blue-700 rounded-full text-sm font-semibold border border-blue-200">{skill}</span>
               ))}
             </div>
           </div>
@@ -98,9 +77,7 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
         {/* Work Experience */}
         {sortedExperiences.length > 0 && (
           <div className="mb-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 border-l-4 border-blue-600 pl-4">
-              Experience
-            </h3>
+            <h3 className="text-2xl font-bold text-gray-900 mb-6 border-l-4 border-blue-600 pl-4">Experience</h3>
             <div className="space-y-8 pl-6">
               {sortedExperiences.map((exp, index) => (
                 <div key={exp.id || index} className="border-l-2 border-gray-200 pl-6 pb-4">
@@ -108,59 +85,19 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
                     <div className="flex items-start justify-between">
                       <div>
                         <h4 className="text-xl font-bold text-gray-900">{exp.position}</h4>
-                        <div className="flex items-center text-blue-700 font-semibold mt-1">
-                          <Building2 className="w-4 h-4 mr-1" />
-                          {exp.company}
-                        </div>
+                        <div className="flex items-center text-blue-700 font-semibold mt-1"><Building2 className="w-4 h-4 mr-1" />{exp.company}</div>
                       </div>
                       <div className="text-right text-sm text-gray-600">
-                        <div className="flex items-center">
-                          <Calendar className="w-4 h-4 mr-1" />
-                          {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
-                        </div>
-                        <div className="font-medium text-blue-600 mt-1">
-                          {calculateDuration(exp.startDate, exp.endDate, exp.current)}
-                        </div>
+                        <div className="flex items-center"><Calendar className="w-4 h-4 mr-1" />{formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}</div>
+                        <div className="font-medium text-blue-600 mt-1">{calculateDuration(exp.startDate, exp.endDate, exp.current)}</div>
                       </div>
                     </div>
-                    {exp.location && (
-                      <div className="flex items-center text-gray-600 text-sm mt-1">
-                        <MapPin className="w-4 h-4 mr-1" />
-                        {exp.location}
-                      </div>
-                    )}
+                    {exp.location && <div className="flex items-center text-gray-600 text-sm mt-1"><MapPin className="w-4 h-4 mr-1" />{exp.location}</div>}
                   </div>
 
-                  {exp.description && (
-                    <p className="text-gray-700 mb-3 leading-relaxed">
-                      {exp.description}
-                    </p>
-                  )}
-
-                  {exp.skills && exp.skills.length > 0 && (
-                    <div className="mb-3">
-                      <div className="flex flex-wrap gap-1.5">
-                        {exp.skills.map((skill, i) => (
-                          <span key={i} className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs font-medium">
-                            {skill}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && (
-                    <ul className="space-y-1.5 text-gray-700">
-                      {exp.achievements.map((achievement, i) => (
-                        achievement && (
-                          <li key={i} className="flex items-start">
-                            <span className="inline-block w-1.5 h-1.5 bg-blue-600 rounded-full mr-2 mt-2 flex-shrink-0"></span>
-                            <span>{achievement}</span>
-                          </li>
-                        )
-                      ))}
-                    </ul>
-                  )}
+                  {exp.description && <p className="text-gray-700 mb-3 leading-relaxed">{exp.description}</p>}
+                  {exp.skills && exp.skills.length > 0 && <div className="mb-3"><div className="flex flex-wrap gap-1.5">{exp.skills.map((skill, i) => <span key={i} className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs font-medium">{skill}</span>)}</div></div>}
+                  {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && <ul className="space-y-1.5 text-gray-700">{exp.achievements.map((achievement, i) => achievement && <li key={i} className="flex items-start"><span className="inline-block w-1.5 h-1.5 bg-blue-600 rounded-full mr-2 mt-2 flex-shrink-0"></span><span>{achievement}</span></li>)}</ul>}
                 </div>
               ))}
             </div>
@@ -170,58 +107,24 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
         {/* Education */}
         {education.length > 0 && (
           <div className="mb-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center">
-              <GraduationCap className="w-6 h-6 mr-2" />
-              Education
-            </h3>
-            <div className="space-y-4 pl-6">
-              {education.map((edu, index) => (
-                <div key={index} className="bg-gray-50 p-4 rounded-lg">
-                  <h4 className="text-lg font-bold text-gray-900">{edu.degree}</h4>
-                  <p className="text-blue-700 font-semibold">{edu.institution}</p>
-                  <p className="text-sm text-gray-600 mt-1">
-                    {edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
-                    {edu.gpa && <span className="ml-3">• GPA: {edu.gpa}</span>}
-                  </p>
-                </div>
-              ))}
-            </div>
+            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center"><GraduationCap className="w-6 h-6 mr-2" />Education</h3>
+            <div className="space-y-4 pl-6">{education.map((edu, index) => <div key={index} className="bg-gray-50 p-4 rounded-lg"><h4 className="text-lg font-bold text-gray-900">{edu.degree}</h4><p className="text-blue-700 font-semibold">{edu.institution}</p><p className="text-sm text-gray-600 mt-1">{edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}{edu.gpa && <span className="ml-3">• GPA: {edu.gpa}</span>}</p></div>)}</div>
           </div>
         )}
 
         {/* Certifications */}
         {certifications.length > 0 && (
           <div className="mb-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center">
-              <Award className="w-6 h-6 mr-2" />
-              Certifications
-            </h3>
-            <div className="space-y-3 pl-6">
-              {certifications.map((cert, index) => (
-                <div key={index} className="border-l-2 border-blue-200 pl-4">
-                  <h4 className="font-bold text-gray-900">{cert.name}</h4>
-                  <p className="text-sm text-gray-700">
-                    {cert.issuer}
-                    {cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}
-                    {cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}
-                  </p>
-                </div>
-              ))}
-            </div>
+            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center"><Award className="w-6 h-6 mr-2" />Certifications</h3>
+            <div className="space-y-3 pl-6">{certifications.map((cert, index) => <div key={index} className="border-l-2 border-blue-200 pl-4"><h4 className="font-bold text-gray-900">{cert.name}</h4><p className="text-sm text-gray-700">{cert.issuer}{cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}{cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}</p></div>)}</div>
           </div>
         )}
       </div>
 
-      {/* Footer */}
-      {sortedExperiences.length === 0 && !profile.summary && (
-        <div className="text-center text-gray-400 py-12">
-          <p>Add your profile information and work experiences to generate your resume.</p>
-        </div>
-      )}
+      {sortedExperiences.length === 0 && !profile.summary && <div className="text-center text-gray-400 py-12"><p>Add your profile information and work experiences to generate your resume.</p></div>}
     </div>
   );
 });
 
 ModernTemplate.displayName = 'ModernTemplate';
-
 export default ModernTemplate;

--- a/src/components/resume/templates/ModernTemplate.js
+++ b/src/components/resume/templates/ModernTemplate.js
@@ -68,7 +68,12 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
             </h3>
             <div className="flex flex-wrap gap-2 pl-6">
               {allSkills.map((skill, index) => (
-                <span key={index} className="px-4 py-2 bg-blue-50 text-blue-700 rounded-full text-sm font-semibold border border-blue-200">{skill}</span>
+                <span
+                  key={index}
+                  className="px-4 py-2 bg-blue-50 text-blue-700 rounded-full text-sm font-semibold border border-blue-200"
+                >
+                  {skill}
+                </span>
               ))}
             </div>
           </div>
@@ -77,7 +82,9 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
         {/* Work Experience */}
         {sortedExperiences.length > 0 && (
           <div className="mb-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 border-l-4 border-blue-600 pl-4">Experience</h3>
+            <h3 className="text-2xl font-bold text-gray-900 mb-6 border-l-4 border-blue-600 pl-4">
+              Experience
+            </h3>
             <div className="space-y-8 pl-6">
               {sortedExperiences.map((exp, index) => (
                 <div key={exp.id || index} className="border-l-2 border-gray-200 pl-6 pb-4">
@@ -85,19 +92,59 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
                     <div className="flex items-start justify-between">
                       <div>
                         <h4 className="text-xl font-bold text-gray-900">{exp.position}</h4>
-                        <div className="flex items-center text-blue-700 font-semibold mt-1"><Building2 className="w-4 h-4 mr-1" />{exp.company}</div>
+                        <div className="flex items-center text-blue-700 font-semibold mt-1">
+                          <Building2 className="w-4 h-4 mr-1" />
+                          {exp.company}
+                        </div>
                       </div>
                       <div className="text-right text-sm text-gray-600">
-                        <div className="flex items-center"><Calendar className="w-4 h-4 mr-1" />{formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}</div>
-                        <div className="font-medium text-blue-600 mt-1">{calculateDuration(exp.startDate, exp.endDate, exp.current)}</div>
+                        <div className="flex items-center">
+                          <Calendar className="w-4 h-4 mr-1" />
+                          {formatDate(exp.startDate)} - {exp.current ? 'Present' : formatDate(exp.endDate)}
+                        </div>
+                        <div className="font-medium text-blue-600 mt-1">
+                          {calculateDuration(exp.startDate, exp.endDate, exp.current)}
+                        </div>
                       </div>
                     </div>
-                    {exp.location && <div className="flex items-center text-gray-600 text-sm mt-1"><MapPin className="w-4 h-4 mr-1" />{exp.location}</div>}
+                    {exp.location && (
+                      <div className="flex items-center text-gray-600 text-sm mt-1">
+                        <MapPin className="w-4 h-4 mr-1" />
+                        {exp.location}
+                      </div>
+                    )}
                   </div>
 
-                  {exp.description && <p className="text-gray-700 mb-3 leading-relaxed">{exp.description}</p>}
-                  {exp.skills && exp.skills.length > 0 && <div className="mb-3"><div className="flex flex-wrap gap-1.5">{exp.skills.map((skill, i) => <span key={i} className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs font-medium">{skill}</span>)}</div></div>}
-                  {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && <ul className="space-y-1.5 text-gray-700">{exp.achievements.map((achievement, i) => achievement && <li key={i} className="flex items-start"><span className="inline-block w-1.5 h-1.5 bg-blue-600 rounded-full mr-2 mt-2 flex-shrink-0"></span><span>{achievement}</span></li>)}</ul>}
+                  {exp.description && (
+                    <p className="text-gray-700 mb-3 leading-relaxed">
+                      {exp.description}
+                    </p>
+                  )}
+
+                  {exp.skills && exp.skills.length > 0 && (
+                    <div className="mb-3">
+                      <div className="flex flex-wrap gap-1.5">
+                        {exp.skills.map((skill, i) => (
+                          <span key={i} className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs font-medium">
+                            {skill}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {exp.achievements && exp.achievements.length > 0 && exp.achievements[0] !== '' && (
+                    <ul className="space-y-1.5 text-gray-700">
+                      {exp.achievements.map((achievement, i) => (
+                        achievement && (
+                          <li key={i} className="flex items-start">
+                            <span className="inline-block w-1.5 h-1.5 bg-blue-600 rounded-full mr-2 mt-2 flex-shrink-0"></span>
+                            <span>{achievement}</span>
+                          </li>
+                        )
+                      ))}
+                    </ul>
+                  )}
                 </div>
               ))}
             </div>
@@ -107,24 +154,58 @@ const ModernTemplate = React.forwardRef(({ profile, experiences, education = [],
         {/* Education */}
         {education.length > 0 && (
           <div className="mb-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center"><GraduationCap className="w-6 h-6 mr-2" />Education</h3>
-            <div className="space-y-4 pl-6">{education.map((edu, index) => <div key={index} className="bg-gray-50 p-4 rounded-lg"><h4 className="text-lg font-bold text-gray-900">{edu.degree}</h4><p className="text-blue-700 font-semibold">{edu.institution}</p><p className="text-sm text-gray-600 mt-1">{edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}{edu.gpa && <span className="ml-3">• GPA: {edu.gpa}</span>}</p></div>)}</div>
+            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center">
+              <GraduationCap className="w-6 h-6 mr-2" />
+              Education
+            </h3>
+            <div className="space-y-4 pl-6">
+              {education.map((edu, index) => (
+                <div key={index} className="bg-gray-50 p-4 rounded-lg">
+                  <h4 className="text-lg font-bold text-gray-900">{edu.degree}</h4>
+                  <p className="text-blue-700 font-semibold">{edu.institution}</p>
+                  <p className="text-sm text-gray-600 mt-1">
+                    {edu.graduationYear || `${edu.startYear} - ${edu.endYear}`}
+                    {edu.gpa && <span className="ml-3">• GPA: {edu.gpa}</span>}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         )}
 
         {/* Certifications */}
         {certifications.length > 0 && (
           <div className="mb-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center"><Award className="w-6 h-6 mr-2" />Certifications</h3>
-            <div className="space-y-3 pl-6">{certifications.map((cert, index) => <div key={index} className="border-l-2 border-blue-200 pl-4"><h4 className="font-bold text-gray-900">{cert.name}</h4><p className="text-sm text-gray-700">{cert.issuer}{cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}{cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}</p></div>)}</div>
+            <h3 className="text-2xl font-bold text-gray-900 mb-4 border-l-4 border-blue-600 pl-4 flex items-center">
+              <Award className="w-6 h-6 mr-2" />
+              Certifications
+            </h3>
+            <div className="space-y-3 pl-6">
+              {certifications.map((cert, index) => (
+                <div key={index} className="border-l-2 border-blue-200 pl-4">
+                  <h4 className="font-bold text-gray-900">{cert.name}</h4>
+                  <p className="text-sm text-gray-700">
+                    {cert.issuer}
+                    {cert.issueDate && <span> • {formatDate(cert.issueDate)}</span>}
+                    {cert.expiryDate && <span> • Expires: {formatDate(cert.expiryDate)}</span>}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </div>
 
-      {sortedExperiences.length === 0 && !profile.summary && <div className="text-center text-gray-400 py-12"><p>Add your profile information and work experiences to generate your resume.</p></div>}
+      {/* Footer */}
+      {sortedExperiences.length === 0 && !profile.summary && (
+        <div className="text-center text-gray-400 py-12">
+          <p>Add your profile information and work experiences to generate your resume.</p>
+        </div>
+      )}
     </div>
   );
 });
 
 ModernTemplate.displayName = 'ModernTemplate';
+
 export default ModernTemplate;

--- a/src/hooks/useJobMatch.js
+++ b/src/hooks/useJobMatch.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { analyzeJobDescription } from '../utils/jobMatchUtils';
+
+const STORAGE_KEY = 'job_match_data';
+
+const useJobMatch = (profileData) => {
+  const [jobDescription, setJobDescription] = useState('');
+  const [analysis, setAnalysis] = useState(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const data = JSON.parse(stored);
+        setJobDescription(data.jobDescription || '');
+        setAnalysis(data.analysis || null);
+      }
+    } catch (error) {
+      console.error('Failed to load job match data:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ jobDescription, analysis }));
+    } catch (error) {
+      console.error('Failed to save job match data:', error);
+    }
+  }, [jobDescription, analysis]);
+
+  const analyze = () => {
+    const trimmed = jobDescription.trim();
+    if (!trimmed) return null;
+    const result = analyzeJobDescription(trimmed, profileData);
+    setAnalysis(result);
+    return result;
+  };
+
+  const clear = () => {
+    setJobDescription('');
+    setAnalysis(null);
+    localStorage.removeItem(STORAGE_KEY);
+  };
+
+  return { jobDescription, setJobDescription, analysis, analyze, clear };
+};
+
+export default useJobMatch;

--- a/src/pages/JobMatch.js
+++ b/src/pages/JobMatch.js
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import { AlertCircle, CheckCircle2, ClipboardCheck, FileSearch, Lightbulb, RefreshCw, Target, Trash2, XCircle } from 'lucide-react';
+import Button from '../components/common/Button';
+import useProfile from '../hooks/useProfile';
+import useExperience from '../hooks/useExperience';
+import useResumeSections from '../hooks/useResumeSections';
+import useJobMatch from '../hooks/useJobMatch';
+import { getMatchLabel } from '../utils/jobMatchUtils';
+
+const ScoreCard = ({ score }) => (
+  <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-6 flex items-center gap-6">
+    <div className="w-28 h-28 rounded-full border-8 border-linkedin-100 dark:border-linkedin-900/40 flex items-center justify-center shrink-0">
+      <div className="text-center"><div className="text-3xl font-bold text-linkedin-600">{score}%</div><div className="text-xs text-gray-500">match</div></div>
+    </div>
+    <div><p className="text-sm text-gray-500 dark:text-gray-400">Overall fit</p><h2 className="text-2xl font-bold text-gray-900 dark:text-white">{getMatchLabel(score)}</h2><p className="text-sm text-gray-600 dark:text-gray-300 mt-1">Based only on information saved in your profile.</p></div>
+  </div>
+);
+
+const Pill = ({ children, tone = 'neutral' }) => {
+  const styles = { good: 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300', bad: 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300', neutral: 'bg-gray-100 text-gray-700 dark:bg-slate-700 dark:text-gray-200' };
+  return <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${styles[tone]}`}>{children}</span>;
+};
+
+const JobMatch = () => {
+  const { profile } = useProfile();
+  const { experiences } = useExperience();
+  const { education, certifications, projects } = useResumeSections();
+  const profileData = useMemo(() => ({ profile, experiences, education, certifications, projects }), [profile, experiences, education, certifications, projects]);
+  const { jobDescription, setJobDescription, analysis, analyze, clear } = useJobMatch(profileData);
+
+  const handleAnalyze = () => analyze();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 py-12 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-linkedin-600 rounded-full mb-4"><FileSearch className="w-8 h-8 text-white" /></div>
+          <h1 className="text-4xl font-bold text-gray-800 dark:text-white mb-2">Job Match</h1>
+          <p className="text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">Paste a job description to compare it with your saved career profile. Everything runs locally in your browser — no API key, account, or paid service required.</p>
+        </div>
+
+        <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-6 mb-8">
+          <div className="flex items-center justify-between gap-4 mb-4"><div><h2 className="text-xl font-bold text-gray-900 dark:text-white">Job description</h2><p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Use the complete JD for the most useful comparison.</p></div><div className="hidden sm:flex items-center gap-2 text-xs text-gray-500"><ClipboardCheck className="w-4 h-4" />Runs offline</div></div>
+          <textarea aria-label="Job description" value={jobDescription} onChange={(e) => setJobDescription(e.target.value)} rows={12} className="w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-xl bg-white dark:bg-slate-700 text-gray-800 dark:text-gray-100 focus:ring-2 focus:ring-linkedin-500 focus:border-linkedin-500" placeholder="Paste the job description here...\n\nExample:\nSenior Software Engineer\nRequired: Java, Spring Boot, AWS, Kubernetes\nNice to have: Kafka, Terraform" />
+          <div className="flex flex-wrap gap-3 mt-4"><Button onClick={handleAnalyze} disabled={!jobDescription.trim()}><Target className="w-4 h-4 mr-2" />Analyze Match</Button><Button onClick={clear} variant="secondary" disabled={!jobDescription && !analysis}><Trash2 className="w-4 h-4 mr-2" />Clear</Button></div>
+        </div>
+
+        {!analysis && <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-8 text-center"><Lightbulb className="w-12 h-12 mx-auto text-linkedin-500 mb-3" /><h3 className="text-xl font-bold text-gray-900 dark:text-white">Ready when you are</h3><p className="text-gray-600 dark:text-gray-300 mt-2">Your job description stays in this browser. The matcher uses a transparent, rule-based keyword engine so it remains completely free.</p></div>}
+
+        {analysis && <div className="space-y-8">
+          <ScoreCard score={analysis.score} />
+          <div className="grid md:grid-cols-3 gap-4">
+            {[['Required skills', analysis.requiredScore], ['Keyword coverage', analysis.keywordScore], ['Preferred skills', analysis.preferredScore]].map(([label, value]) => <div key={label} className="bg-white dark:bg-slate-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5"><p className="text-sm text-gray-500 dark:text-gray-400">{label}</p><p className="text-3xl font-bold text-gray-900 dark:text-white mt-1">{value}%</p></div>)}
+          </div>
+
+          <div className="grid lg:grid-cols-2 gap-6">
+            <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-6"><h3 className="text-lg font-bold text-gray-900 dark:text-white flex items-center mb-4"><CheckCircle2 className="w-5 h-5 mr-2 text-green-600" />Matched</h3><div className="flex flex-wrap gap-2">{analysis.matched.length ? analysis.matched.map((item) => <Pill key={item} tone="good">{item}</Pill>) : <p className="text-sm text-gray-500">No detected keyword matches yet.</p>}</div></div>
+            <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-6"><h3 className="text-lg font-bold text-gray-900 dark:text-white flex items-center mb-4"><XCircle className="w-5 h-5 mr-2 text-red-600" />Gaps</h3><div className="flex flex-wrap gap-2">{analysis.missing.length ? analysis.missing.map((item) => <Pill key={item} tone="bad">{item}</Pill>) : <p className="text-sm text-gray-500">No detected keyword gaps.</p>}</div></div>
+          </div>
+
+          <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-700 p-6"><div className="flex items-center justify-between mb-5"><div><h3 className="text-lg font-bold text-gray-900 dark:text-white">Skill coverage</h3><p className="text-sm text-gray-500 dark:text-gray-400">Only categories mentioned in the JD are shown.</p></div>{analysis.seniority && <Pill>{analysis.seniority}</Pill>}</div><div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">{analysis.categories.map((category) => <div key={category.name} className="border border-gray-200 dark:border-gray-700 rounded-xl p-4"><div className="flex justify-between mb-2"><span className="font-semibold text-gray-800 dark:text-white">{category.name}</span><span className="text-sm font-bold text-linkedin-600">{category.score}%</span></div><div className="h-2 bg-gray-100 dark:bg-slate-700 rounded-full overflow-hidden"><div className="h-full bg-linkedin-600" style={{ width: `${category.score}%` }} /></div><div className="flex flex-wrap gap-1 mt-3">{category.matched.map((item) => <Pill key={item} tone="good">{item}</Pill>)}{category.missing.map((item) => <Pill key={item} tone="bad">{item}</Pill>)}</div></div>)}</div></div>
+
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-2xl p-5 flex gap-3"><AlertCircle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" /><div><h3 className="font-bold text-amber-900 dark:text-amber-200">Transparent by design</h3><p className="text-sm text-amber-800 dark:text-amber-300 mt-1">This first version is intentionally deterministic. It does not invent experience or send your resume to a third-party AI service. Future AI features can build on this analysis without changing the free local-first foundation.</p></div></div>
+          <div className="text-center"><Button onClick={handleAnalyze} variant="secondary"><RefreshCw className="w-4 h-4 mr-2" />Re-analyze</Button></div>
+        </div>}
+      </div>
+    </div>
+  );
+};
+
+export default JobMatch;

--- a/src/utils/jobMatchUtils.js
+++ b/src/utils/jobMatchUtils.js
@@ -1,0 +1,81 @@
+const SKILL_GROUPS = {
+  Languages: ['javascript', 'typescript', 'java', 'python', 'go', 'golang', 'c++', 'c#', 'ruby', 'kotlin', 'swift', 'rust', 'php'],
+  Backend: ['node.js', 'nodejs', 'spring boot', 'spring', 'express', 'rest api', 'rest apis', 'graphql', 'microservices', 'distributed systems', 'api design'],
+  Frontend: ['react', 'next.js', 'nextjs', 'angular', 'vue', 'html', 'css', 'tailwind'],
+  Cloud: ['aws', 'amazon web services', 'azure', 'gcp', 'google cloud', 'cloud computing', 'serverless'],
+  Data: ['sql', 'postgresql', 'postgres', 'mysql', 'mongodb', 'redis', 'dynamodb', 'kafka', 'spark', 'elasticsearch'],
+  DevOps: ['docker', 'kubernetes', 'k8s', 'terraform', 'jenkins', 'github actions', 'ci/cd', 'linux'],
+  Security: ['oauth', 'oauth2', 'oidc', 'saml', 'authentication', 'authorization', 'identity', 'security'],
+  Tools: ['git', 'github', 'jira', 'datadog', 'prometheus', 'grafana']
+};
+
+const SENIORITY = ['intern', 'junior', 'mid-level', 'mid level', 'senior', 'staff', 'principal', 'lead', 'manager'];
+const EDUCATION = ['bachelor', "bachelor's", 'master', "master's", 'phd', 'degree', 'computer science'];
+
+const normalize = (value = '') => value.toLowerCase().replace(/[\u2018\u2019]/g, "'").replace(/[^a-z0-9+#./\-\s]/g, ' ').replace(/\s+/g, ' ').trim();
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const containsTerm = (text, term) => new RegExp(`(^|[^a-z0-9+#])${escapeRegExp(term)}(?=$|[^a-z0-9+#])`, 'i').test(text);
+
+export const extractKeywords = (jobDescription) => {
+  const text = normalize(jobDescription);
+  const keywords = [];
+  Object.values(SKILL_GROUPS).flat().forEach((skill) => {
+    if (containsTerm(text, skill) && !keywords.includes(skill)) keywords.push(skill);
+  });
+  SENIORITY.concat(EDUCATION).forEach((term) => {
+    if (containsTerm(text, term) && !keywords.includes(term)) keywords.push(term);
+  });
+  return keywords;
+};
+
+export const extractRequirements = (jobDescription) => {
+  const required = [];
+  const preferred = [];
+  const lines = jobDescription.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const preferredContext = /(preferred|nice to have|bonus|plus|desired|preferred qualifications)/i;
+  const skillTerms = Object.values(SKILL_GROUPS).flat();
+  lines.forEach((line) => {
+    const normalizedLine = normalize(line);
+    skillTerms.filter((skill) => containsTerm(normalizedLine, skill)).forEach((skill) => {
+      const target = preferredContext.test(line) ? preferred : required;
+      if (!target.includes(skill)) target.push(skill);
+    });
+  });
+  return { required, preferred };
+};
+
+const buildProfileText = ({ profile = {}, experiences = [], education = [], certifications = [], projects = [] }) => normalize([
+  profile.headline, profile.summary,
+  ...experiences.flatMap((e) => [e.position, e.company, e.description, ...(e.skills || []), ...(e.achievements || [])]),
+  ...education.flatMap((e) => [e.degree, e.institution, e.gpa]),
+  ...certifications.flatMap((c) => [c.name, c.issuer]),
+  ...projects.flatMap((p) => [p.name, p.description, p.technologies])
+].filter(Boolean).join(' '));
+
+export const analyzeJobDescription = (jobDescription, profileData) => {
+  const text = normalize(jobDescription);
+  const profileText = buildProfileText(profileData);
+  const keywords = extractKeywords(jobDescription);
+  const { required, preferred } = extractRequirements(jobDescription);
+  const matched = keywords.filter((keyword) => containsTerm(profileText, keyword));
+  const missing = keywords.filter((keyword) => !containsTerm(profileText, keyword));
+  const matchedRequired = required.filter((keyword) => containsTerm(profileText, keyword));
+  const matchedPreferred = preferred.filter((keyword) => containsTerm(profileText, keyword));
+  const requiredScore = required.length ? Math.round((matchedRequired.length / required.length) * 100) : 100;
+  const preferredScore = preferred.length ? Math.round((matchedPreferred.length / preferred.length) * 100) : 100;
+  const keywordScore = keywords.length ? Math.round((matched.length / keywords.length) * 100) : 100;
+  const educationMentioned = EDUCATION.some((term) => containsTerm(text, term));
+  const educationMatch = !educationMentioned || (profileData.education || []).length > 0 ? 100 : 0;
+  const score = Math.round(requiredScore * 0.6 + keywordScore * 0.25 + preferredScore * 0.1 + educationMatch * 0.05);
+  const categories = Object.entries(SKILL_GROUPS).map(([name, skills]) => {
+    const relevant = skills.filter((skill) => containsTerm(text, skill));
+    const hits = relevant.filter((skill) => containsTerm(profileText, skill));
+    return { name, score: relevant.length ? Math.round((hits.length / relevant.length) * 100) : null, matched: hits, missing: relevant.filter((skill) => !hits.includes(skill)) };
+  }).filter((category) => category.score !== null);
+  const seniority = SENIORITY.find((term) => containsTerm(text, term));
+  return { score, keywords, matched, missing, required, preferred, matchedRequired, matchedPreferred, requiredScore, preferredScore, keywordScore, educationMatch, seniority, categories, generatedAt: new Date().toISOString() };
+};
+
+export const getMatchLabel = (score) => score >= 85 ? 'Strong match' : score >= 70 ? 'Good match' : score >= 50 ? 'Partial match' : 'Low match';
+
+export default analyzeJobDescription;


### PR DESCRIPTION
## Summary
- add a fully local, deterministic Job Match page
- compare job descriptions against profile, experience, education, certifications and projects
- show overall score, required/preferred coverage, matched keywords, gaps and category coverage
- persist the JD and analysis in LocalStorage
- add unit tests for the matching engine
- add Playwright desktop/mobile regression tests for the Job Match flow
- update README with the free/local-first architecture and roadmap

## Free-use requirement
This feature adds no paid service, AI API, backend, account, API key, or new dependency. Analysis runs entirely in the browser.

## Validation
CI should run unit tests, production build, Playwright browser regression tests, and only then deploy to GitHub Pages.